### PR TITLE
feat: add osx64 as a build platform

### DIFF
--- a/.github/workflows/rattler-build.yml
+++ b/.github/workflows/rattler-build.yml
@@ -33,7 +33,7 @@ jobs:
           - { target: linux-64, os: ubuntu-20.04 }
           - { target: win-64, os: windows-latest }
           # force older macos-13 to get x86_64 runners
-          # - { target: osx-64, os: macos-13 }
+          - { target: osx-64, os: macos-13 }
           - { target: osx-arm64, os: macos-14 }
       fail-fast: false
 


### PR DESCRIPTION
Adds osx64, so that a conda package would be built for this. We need this for testing in pixi ci.