### PR TITLE
create work directory

### DIFF
--- a/crates/pixi-build/src/bin/pixi-build-rattler-build/rattler_build.rs
+++ b/crates/pixi-build/src/bin/pixi-build-rattler-build/rattler_build.rs
@@ -93,6 +93,9 @@ impl Protocol for RattlerBuildBackend {
 
         let selector_config = RattlerBuild::selector_config_from(&params);
 
+        // Create the work directory if it does not exist
+        std::fs::create_dir_all(&params.work_directory).into_diagnostic()?;
+
         let rattler_build_tool = RattlerBuild::new(
             self.raw_recipe.clone(),
             self.recipe_path.clone(),


### PR DESCRIPTION
The comment says that it might not exist yet. And indeed, I had to manually create the `.pixi/builds-v0` folder before I could run rattler-build. I think this might be safer?