### PR TITLE
feat: turn wildcards into name-only specs

### DIFF
--- a/crates/pixi-build/src/bin/pixi-build-cmake/snapshots/pixi_build_cmake__cmake__tests__setting_host_and_build_requirements-2.snap
+++ b/crates/pixi-build/src/bin/pixi-build-cmake/snapshots/pixi_build_cmake__cmake__tests__setting_host_and_build_requirements-2.snap
@@ -12,11 +12,11 @@ build:
   script: "[ ... script ... ]"
 requirements:
   build:
-    - boltons *
+    - boltons
     - "... compiler ..."
   host:
-    - hatchling *
-    - cmake *
-    - ninja *
+    - hatchling
+    - cmake
+    - ninja
   run:
     - foobar ==3.2.1

--- a/crates/pixi-build/src/bin/pixi-build-cmake/snapshots/pixi_build_cmake__cmake__tests__setting_host_and_build_requirements.snap
+++ b/crates/pixi-build/src/bin/pixi-build-cmake/snapshots/pixi_build_cmake__cmake__tests__setting_host_and_build_requirements.snap
@@ -3,11 +3,11 @@ source: crates/pixi-build/src/bin/pixi-build-cmake/cmake.rs
 expression: reqs
 ---
 build:
-  - boltons *
+  - boltons
   - "... compiler ..."
 host:
-  - hatchling *
-  - cmake *
-  - ninja *
+  - hatchling
+  - cmake
+  - ninja
 run:
   - foobar ==3.2.1

--- a/crates/pixi-build/src/bin/pixi-build-python/snapshots/pixi_build_python__python__tests__noarch_none.snap
+++ b/crates/pixi-build/src/bin/pixi-build-python/snapshots/pixi_build_python__python__tests__noarch_none.snap
@@ -14,5 +14,5 @@ build:
   script: "[ ... script ... ]"
 requirements:
   host:
-    - pip *
-    - python *
+    - pip
+    - python

--- a/crates/pixi-build/src/bin/pixi-build-python/snapshots/pixi_build_python__python__tests__noarch_python.snap
+++ b/crates/pixi-build/src/bin/pixi-build-python/snapshots/pixi_build_python__python__tests__noarch_python.snap
@@ -15,5 +15,5 @@ build:
   noarch: python
 requirements:
   host:
-    - pip *
-    - python *
+    - pip
+    - python

--- a/crates/pixi-build/src/bin/pixi-build-python/snapshots/pixi_build_python__python__tests__setting_host_and_build_requirements-2.snap
+++ b/crates/pixi-build/src/bin/pixi-build-python/snapshots/pixi_build_python__python__tests__setting_host_and_build_requirements-2.snap
@@ -15,10 +15,10 @@ build:
   noarch: python
 requirements:
   build:
-    - boltons *
+    - boltons
   host:
-    - hatchling *
-    - pip *
-    - python *
+    - hatchling
+    - pip
+    - python
   run:
     - foobar >=3.2.1

--- a/crates/pixi-build/src/bin/pixi-build-python/snapshots/pixi_build_python__python__tests__setting_host_and_build_requirements.snap
+++ b/crates/pixi-build/src/bin/pixi-build-python/snapshots/pixi_build_python__python__tests__setting_host_and_build_requirements.snap
@@ -3,10 +3,10 @@ source: crates/pixi-build/src/bin/pixi-build-python/python.rs
 expression: reqs
 ---
 build:
-  - boltons *
+  - boltons
 host:
-  - hatchling *
-  - pip *
-  - python *
+  - hatchling
+  - pip
+  - python
 run:
   - foobar >=3.2.1

--- a/crates/pixi-build/src/dependencies.rs
+++ b/crates/pixi-build/src/dependencies.rs
@@ -55,7 +55,12 @@ impl<'a> MatchspecExtractor<'a> {
                     let nameless_spec = binary
                         .try_into_nameless_match_spec(self.channel_config)
                         .into_diagnostic()?;
-                    MatchSpec::from_nameless(nameless_spec, Some(name))
+                    if nameless_spec.version == Some("*".parse().unwrap()) {
+                        // Skip dependencies with wildcard versions.
+                        name.as_normalized().to_string().parse().unwrap()
+                    } else {
+                        MatchSpec::from_nameless(nameless_spec, Some(name))
+                    }
                 }
             };
 


### PR DESCRIPTION
So that `variants` work the rattler-build way.