### PR TITLE
feat: support editable installs for `pixi build`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "jobserver",
  "libc",
@@ -554,9 +554,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -1091,22 +1091,22 @@ dependencies = [
 [[package]]
 name = "fancy_display"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#8070a89a4a7ea228c5703ef71a2a980ae91e1e76"
+source = "git+https://github.com/Hofer-Julian/pixi?branch=feat/build-editable#6f2e57db17ef3b0c596ec0514f07cf21d5aa5cf4"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file_url"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff487eda48708def359958613c6c9762d9c4f8396db240e37083758ccb01c79"
+checksum = "c2789b7b3e160530d89d1e126aff9811c3421bb77ebb9b62ffa3abbeba69f12d"
 dependencies = [
  "itertools 0.13.0",
  "percent-encoding",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "file_url"
 version = "0.2.0"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "itertools 0.13.0",
  "percent-encoding",
@@ -2048,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2187,9 +2187,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libdbus-sys"
@@ -2797,10 +2797,11 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pep440_rs"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0922a442c78611fa8c5ed6065d2d898a820cf12fa90604217fdb2d01675efec7"
+checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
 dependencies = [
+ "once_cell",
  "serde",
  "unicode-width 0.2.0",
  "unscanny",
@@ -2837,20 +2838,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2858,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2871,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
 dependencies = [
  "once_cell",
  "pest",
@@ -3019,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "pixi_build_types"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#8070a89a4a7ea228c5703ef71a2a980ae91e1e76"
+source = "git+https://github.com/Hofer-Julian/pixi?branch=feat/build-editable#6f2e57db17ef3b0c596ec0514f07cf21d5aa5cf4"
 dependencies = [
  "rattler_conda_types",
  "serde",
@@ -3031,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "pixi_consts"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#8070a89a4a7ea228c5703ef71a2a980ae91e1e76"
+source = "git+https://github.com/Hofer-Julian/pixi?branch=feat/build-editable#6f2e57db17ef3b0c596ec0514f07cf21d5aa5cf4"
 dependencies = [
  "console",
  "lazy_static",
@@ -3042,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "pixi_manifest"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#8070a89a4a7ea228c5703ef71a2a980ae91e1e76"
+source = "git+https://github.com/Hofer-Julian/pixi?branch=feat/build-editable#6f2e57db17ef3b0c596ec0514f07cf21d5aa5cf4"
 dependencies = [
  "console",
  "dunce",
@@ -3075,10 +3076,10 @@ dependencies = [
 [[package]]
 name = "pixi_spec"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#8070a89a4a7ea228c5703ef71a2a980ae91e1e76"
+source = "git+https://github.com/Hofer-Julian/pixi?branch=feat/build-editable#6f2e57db17ef3b0c596ec0514f07cf21d5aa5cf4"
 dependencies = [
  "dirs",
- "file_url 0.1.7",
+ "file_url 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.13.0",
  "rattler_conda_types",
  "rattler_digest 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3268,8 +3269,8 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.28.4"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+version = "0.28.5"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "anyhow",
  "clap",
@@ -3309,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "rattler-build"
 version = "0.31.1"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#15f70b20f3cc20494f64e1bfa7dd91367fdd6ade"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#b3f6bd25067177a4b7937a3960d2e2da196b249a"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3374,7 +3375,7 @@ dependencies = [
  "tar",
  "tempfile",
  "terminal_size",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util 0.7.13",
  "toml",
@@ -3391,8 +3392,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.2.12"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+version = "0.2.13"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3420,11 +3421,11 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.29.3"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "chrono",
  "dirs",
- "file_url 0.2.0",
+ "file_url 0.2.0 (git+https://github.com/conda/rattler?branch=main)",
  "fxhash",
  "glob",
  "hex",
@@ -3471,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.0.3"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "blake2",
  "digest",
@@ -3502,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.3"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "quote",
  "syn",
@@ -3510,8 +3511,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.21.7"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+version = "0.21.8"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3536,8 +3537,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.15"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+version = "0.22.16"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "bzip2",
  "chrono",
@@ -3565,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.1.4"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -3574,8 +3575,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.24"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+version = "0.21.25"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3587,7 +3588,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "dirs",
- "file_url 0.2.0",
+ "file_url 0.2.0 (git+https://github.com/conda/rattler?branch=main)",
  "fs-err 3.0.0",
  "futures",
  "hex",
@@ -3648,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.22.8"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "enum_dispatch",
  "fs-err 3.0.0",
@@ -3665,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "1.2.4"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "chrono",
  "futures",
@@ -3683,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "1.1.11"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "archspec",
  "libloading",
@@ -3960,15 +3961,15 @@ checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4332,7 +4333,7 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.0.0"
-source = "git+https://github.com/conda/rattler?branch=main#c125172a6a6998eca33631619f8174772a044cea"
+source = "git+https://github.com/conda/rattler?branch=main#ddb05cef58d59577191dd5b2ea240aed214d4a2d"
 dependencies = [
  "tokio",
 ]
@@ -4611,11 +4612,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
 dependencies = [
- "thiserror-impl 2.0.4",
+ "thiserror-impl 2.0.6",
 ]
 
 [[package]]
@@ -4631,9 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4731,20 +4732,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5093,9 +5093,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
@@ -5104,13 +5104,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -5119,9 +5118,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5132,9 +5131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5142,9 +5141,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5155,9 +5154,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-streams"
@@ -5174,9 +5173,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5772,7 +5771,7 @@ dependencies = [
  "flate2",
  "indexmap 2.7.0",
  "memchr",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "time",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,11 @@ rattler_conda_types = { version = "0.29.1", default-features = false }
 rattler_package_streaming = { version = "0.22.14", default-features = false }
 rattler_virtual_packages = { version = "1.1.10", default-features = false }
 
-pixi_build_types = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
-pixi_consts = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
-pixi_manifest = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
-pixi_spec = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
+# TODO change back to prefix.dev
+pixi_build_types = { git = "https://github.com/Hofer-Julian/pixi", branch = "feat/build-editable" }
+pixi_consts = { git = "https://github.com/Hofer-Julian/pixi", branch = "feat/build-editable" }
+pixi_manifest = { git = "https://github.com/Hofer-Julian/pixi", branch = "feat/build-editable" }
+pixi_spec = { git = "https://github.com/Hofer-Julian/pixi", branch = "feat/build-editable" }
 
 [patch.crates-io]
 rattler = { git = "https://github.com/conda/rattler", branch = "main" }

--- a/crates/pixi-build/src/bin/pixi-build-python/build_script.j2
+++ b/crates/pixi-build/src/bin/pixi-build-python/build_script.j2
@@ -1,10 +1,12 @@
 {% set PYTHON="%PYTHON%" if build_platform == "windows" else "$PYTHON" -%}
-{% set SRC_DIR="%SRC_DIR%" if build_platform == "windows" else "$SRC_DIR" -%}
+{% set SRC_DIR = manifest_root if editable else ("%SRC_DIR%" if build_platform == "windows" else "$SRC_DIR") -%}
+{% set EDITABLE_OPTION = " --editable" if editable else "" -%}
+{% set COMMON_OPTIONS = "-vv --no-deps --no-build-isolation" + EDITABLE_OPTION -%}
 
 {% if installer == "uv" -%}
-uv pip install --python {{ PYTHON }} -vv --no-deps --no-build-isolation {{ SRC_DIR }}
+uv pip install --python {{ PYTHON }} {{ COMMON_OPTIONS }} {{ SRC_DIR }}
 {% else %}
-{{ PYTHON }} -m pip install -vv --ignore-installed --no-deps --no-build-isolation {{ SRC_DIR }}
+{{ PYTHON }} -m pip install --ignore-installed {{ COMMON_OPTIONS }} {{ SRC_DIR }}
 {% endif -%}
 
 {% if build_platform == "windows" -%}

--- a/crates/pixi-build/src/bin/pixi-build-python/build_script.rs
+++ b/crates/pixi-build/src/bin/pixi-build-python/build_script.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use minijinja::Environment;
 use serde::Serialize;
 
@@ -5,6 +7,8 @@ use serde::Serialize;
 pub struct BuildScriptContext {
     pub installer: Installer,
     pub build_platform: BuildPlatform,
+    pub editable: bool,
+    pub manifest_root: PathBuf,
 }
 
 #[derive(Default, Serialize)]

--- a/crates/pixi-build/src/bin/pixi-build-python/python.rs
+++ b/crates/pixi-build/src/bin/pixi-build-python/python.rs
@@ -231,7 +231,7 @@ impl PythonBuildBackend {
                 BuildPlatform::Unix
             },
             // TODO: remove this as soon as we have profiles
-            editable: std::env::var("EDITABLE_PYTHON")
+            editable: std::env::var("BUILD_EDITABLE_PYTHON")
                 .map(|val| val == "true")
                 .unwrap_or(editable),
             manifest_root: manifest_root.to_path_buf(),

--- a/crates/pixi-build/src/bin/pixi-build-python/python.rs
+++ b/crates/pixi-build/src/bin/pixi-build-python/python.rs
@@ -1,11 +1,3 @@
-use std::{
-    borrow::Cow,
-    collections::BTreeMap,
-    path::{Path, PathBuf},
-    str::FromStr,
-    sync::Arc,
-};
-
 use chrono::Utc;
 use itertools::Itertools;
 use jsonrpc_core::serde_json;
@@ -48,6 +40,13 @@ use rattler_conda_types::{
 use rattler_package_streaming::write::CompressionLevel;
 use rattler_virtual_packages::VirtualPackageOverrides;
 use reqwest::Url;
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
 
 use crate::{
     build_script::{BuildPlatform, BuildScriptContext, Installer},
@@ -183,6 +182,7 @@ impl PythonBuildBackend {
         &self,
         host_platform: Platform,
         channel_config: &ChannelConfig,
+        editable: bool,
     ) -> miette::Result<Recipe> {
         let manifest_root = self
             .manifest
@@ -230,8 +230,28 @@ impl PythonBuildBackend {
             } else {
                 BuildPlatform::Unix
             },
+            // TODO: remove this as soon as we have profiles
+            editable: std::env::var("EDITABLE_PYTHON")
+                .map(|val| val == "true")
+                .unwrap_or(editable),
+            manifest_root: manifest_root.to_path_buf(),
         }
         .render();
+
+        let source = if editable {
+            Vec::new()
+        } else {
+            Vec::from([Source::Path(PathSource {
+                // TODO: How can we use a git source?
+                path: manifest_root.to_path_buf(),
+                sha256: None,
+                md5: None,
+                patches: vec![],
+                target_directory: None,
+                file_name: None,
+                use_gitignore: true,
+            })])
+        };
 
         Ok(Recipe {
             schema_version: 1,
@@ -241,16 +261,7 @@ impl PythonBuildBackend {
             },
             context: Default::default(),
             cache: None,
-            source: vec![Source::Path(PathSource {
-                // TODO: How can we use a git source?
-                path: manifest_root.to_path_buf(),
-                sha256: None,
-                md5: None,
-                patches: vec![],
-                target_directory: None,
-                file_name: None,
-                use_gitignore: true,
-            })],
+            source,
             build: Build {
                 number: build_number,
                 string: Default::default(),
@@ -468,7 +479,7 @@ impl Protocol for PythonBuildBackend {
         }
 
         // TODO: Determine how and if we can determine this from the manifest.
-        let recipe = self.recipe(host_platform, &channel_config)?;
+        let recipe = self.recipe(host_platform, &channel_config, false)?;
         let output = Output {
             build_configuration: self
                 .build_configuration(
@@ -561,7 +572,7 @@ impl Protocol for PythonBuildBackend {
             miette::bail!("the project does not support the target platform ({host_platform})");
         }
 
-        let recipe = self.recipe(host_platform, &channel_config)?;
+        let recipe = self.recipe(host_platform, &channel_config, params.editable)?;
         let output = Output {
             build_configuration: self
                 .build_configuration(&recipe, channels, None, None, &params.work_directory)
@@ -657,7 +668,7 @@ mod tests {
 
         let channel_config = ChannelConfig::default_with_root_dir(tmp_dir.path().to_path_buf());
         python_backend
-            .recipe(Platform::current(), &channel_config)
+            .recipe(Platform::current(), &channel_config, false)
             .unwrap()
     }
 
@@ -755,7 +766,7 @@ mod tests {
 
         insta::assert_yaml_snapshot!(reqs);
 
-        let recipe = python_backend.recipe(host_platform, &channel_config);
+        let recipe = python_backend.recipe(host_platform, &channel_config, false);
         insta::assert_yaml_snapshot!(recipe.unwrap(), {
             ".source[0].path" => "[ ... path ... ]",
             ".build.script" => "[ ... script ... ]",

--- a/crates/pixi-build/src/bin/pixi-build-rattler-build/rattler_build.rs
+++ b/crates/pixi-build/src/bin/pixi-build-rattler-build/rattler_build.rs
@@ -446,6 +446,7 @@ mod tests {
                 outputs: None,
                 work_directory: current_dir.into_path(),
                 variant_configuration: None,
+                editable: false,
             })
             .await
             .unwrap();

--- a/crates/pixi-build/src/cli.rs
+++ b/crates/pixi-build/src/cli.rs
@@ -172,6 +172,7 @@ async fn build(factory: impl ProtocolFactory, manifest_path: &Path) -> miette::R
             outputs: None,
             work_directory: work_dir.path().to_path_buf(),
             variant_configuration: None,
+            editable: false,
         })
         .await?;
 


### PR DESCRIPTION
Only `pixi-build-python` handles the `editable` parameter
