### PR TITLE
feat: add `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`

### DIFF
--- a/crates/pixi-build/src/bin/pixi-build-cmake/build_script.j2
+++ b/crates/pixi-build/src/bin/pixi-build-cmake/build_script.j2
@@ -8,6 +8,7 @@ if not exist %SRC_DIR%\..\build\CMakeCache.txt (
           -GNinja ^
           -DCMAKE_BUILD_TYPE=Release ^
           -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
           -DBUILD_SHARED_LIBS=ON ^
           -B %SRC_DIR%\..\build ^
           -S "{{ source_dir }}"
@@ -23,6 +24,7 @@ if [ ! -f "$SRC_DIR/../build/CMakeCache.txt" ]; then
           -GNinja \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=$PREFIX \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DBUILD_SHARED_LIBS=ON \
           -B $SRC_DIR/../build \
           -S "{{ source_dir }}"


### PR DESCRIPTION
As discussed in #39 this PR adds `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to the default cmake invocation. This will [make cmake generate the `compile_commands.json` file in the build directory.](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html) 

In the future it would probably be good to couple this to the "profiles" feature.