### PR TITLE
add into_diagnostic

### DIFF
--- a/crates/pixi-build/src/tools.rs
+++ b/crates/pixi-build/src/tools.rs
@@ -162,7 +162,8 @@ impl RattlerBuild {
                         .collect::<Vec<ParsingError>>()
                         .into();
                     errs
-                }).into_diagnostic()?;
+                })
+                .into_diagnostic()?;
 
             if recipe.build().skip() {
                 eprintln!(

--- a/crates/pixi-build/src/tools.rs
+++ b/crates/pixi-build/src/tools.rs
@@ -162,7 +162,7 @@ impl RattlerBuild {
                         .collect::<Vec<ParsingError>>()
                         .into();
                     errs
-                })?;
+                }).into_diagnostic()?;
 
             if recipe.build().skip() {
                 eprintln!(


### PR DESCRIPTION
I am not sure if this helps but this is what the source of `ParseErrors` looks like ... 

```rust
/// Collection of parse errors to build related diagnostics
#[derive(Error, Debug, Diagnostic)]
#[error("Failed to parse recipe")]
pub struct ParseErrors {
    #[related]
    errs: Vec<ParsingError>,
}
```