### PR TITLE
feat: remove reading from the manifest 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,7 +941,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -952,8 +961,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1116,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "fancy_display"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
  "console",
 ]
@@ -3074,6 +3095,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap-verbosity-flag",
+ "dirs 6.0.0",
  "fs-err",
  "indexmap 2.7.0",
  "insta",
@@ -3110,9 +3132,10 @@ dependencies = [
 [[package]]
 name = "pixi_build_type_conversions"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
  "indexmap 2.7.0",
+ "itertools 0.13.0",
  "pixi_build_types",
  "pixi_manifest",
  "pixi_spec",
@@ -3123,7 +3146,7 @@ dependencies = [
 [[package]]
 name = "pixi_build_types"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
  "indexmap 2.7.0",
  "rattler_conda_types",
@@ -3137,11 +3160,11 @@ dependencies = [
 [[package]]
 name = "pixi_config"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
  "clap",
  "console",
- "dirs",
+ "dirs 5.0.1",
  "fs-err",
  "itertools 0.13.0",
  "miette",
@@ -3162,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "pixi_consts"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
  "console",
  "rattler_cache",
@@ -3173,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "pixi_git"
 version = "0.0.1"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
  "dashmap",
  "dunce",
@@ -3194,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "pixi_manifest"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
  "console",
  "dunce",
@@ -3227,9 +3250,9 @@ dependencies = [
 [[package]]
 name = "pixi_spec"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
- "dirs",
+ "dirs 5.0.1",
  "file_url",
  "itertools 0.13.0",
  "pixi_git",
@@ -3250,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "pixi_toml"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
  "digest",
  "hex",
@@ -3263,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "pixi_utils"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
 dependencies = [
  "fd-lock",
  "fs-err",
@@ -3525,7 +3548,7 @@ dependencies = [
  "clap",
  "console",
  "digest",
- "dirs",
+ "dirs 5.0.1",
  "fs-err",
  "futures",
  "humantime",
@@ -3651,7 +3674,7 @@ dependencies = [
  "anyhow",
  "dashmap",
  "digest",
- "dirs",
+ "dirs 5.0.1",
  "fs-err",
  "fs4",
  "futures",
@@ -3679,7 +3702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f21a09d833d1436694fdd055c6de5c673405c14ca6cc9598419f76643cbb691c"
 dependencies = [
  "chrono",
- "dirs",
+ "dirs 5.0.1",
  "file_url",
  "fs-err",
  "fxhash",
@@ -3762,7 +3785,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
- "dirs",
+ "dirs 5.0.1",
  "fslock",
  "getrandom",
  "google-cloud-auth",
@@ -3836,7 +3859,7 @@ dependencies = [
  "cache_control",
  "chrono",
  "dashmap",
- "dirs",
+ "dirs 5.0.1",
  "file_url",
  "fs-err",
  "futures",
@@ -3992,6 +4015,17 @@ dependencies = [
  "getrandom",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.10",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "fancy_display"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
 dependencies = [
  "console",
 ]
@@ -3085,6 +3085,7 @@ dependencies = [
  "miette",
  "minijinja",
  "parking_lot 0.12.3",
+ "pixi_build_type_conversions",
  "pixi_build_types",
  "pixi_consts",
  "pixi_manifest",
@@ -3107,12 +3108,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pixi_build_type_conversions"
+version = "0.1.0"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
+dependencies = [
+ "indexmap 2.7.0",
+ "pixi_build_types",
+ "pixi_manifest",
+ "pixi_spec",
+ "rattler_conda_types",
+ "serde_json",
+]
+
+[[package]]
 name = "pixi_build_types"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
 dependencies = [
+ "indexmap 2.7.0",
  "rattler_conda_types",
+ "rattler_digest",
  "serde",
+ "serde_json",
  "serde_with",
  "url",
 ]
@@ -3120,7 +3137,7 @@ dependencies = [
 [[package]]
 name = "pixi_config"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
 dependencies = [
  "clap",
  "console",
@@ -3145,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "pixi_consts"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
 dependencies = [
  "console",
  "rattler_cache",
@@ -3156,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "pixi_git"
 version = "0.0.1"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
 dependencies = [
  "dashmap",
  "dunce",
@@ -3177,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "pixi_manifest"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
 dependencies = [
  "console",
  "dunce",
@@ -3191,7 +3208,6 @@ dependencies = [
  "pixi_consts",
  "pixi_spec",
  "pixi_toml",
- "pixi_utils",
  "pyproject-toml",
  "rattler_conda_types",
  "rattler_virtual_packages",
@@ -3211,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "pixi_spec"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
 dependencies = [
  "dirs",
  "file_url",
@@ -3226,6 +3242,7 @@ dependencies = [
  "thiserror 2.0.10",
  "toml-span",
  "toml_edit",
+ "tracing",
  "typed-path",
  "url",
 ]
@@ -3233,7 +3250,7 @@ dependencies = [
 [[package]]
 name = "pixi_toml"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
 dependencies = [
  "digest",
  "hex",
@@ -3246,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "pixi_utils"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/tdejager/pixi?branch=feat/build-type-helper-method#e5e62d451d1b552d86cc022f0f755e2919655edd"
 dependencies = [
  "fd-lock",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "fancy_display"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
  "console",
 ]
@@ -1147,17 +1147,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
-dependencies = [
- "cfg-if 1.0.0",
- "rustix",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "file_url"
@@ -3132,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "pixi_build_type_conversions"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
  "indexmap 2.7.0",
  "itertools 0.13.0",
@@ -3140,13 +3129,12 @@ dependencies = [
  "pixi_manifest",
  "pixi_spec",
  "rattler_conda_types",
- "serde_json",
 ]
 
 [[package]]
 name = "pixi_build_types"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
  "indexmap 2.7.0",
  "rattler_conda_types",
@@ -3160,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "pixi_config"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
  "clap",
  "console",
@@ -3185,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "pixi_consts"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
  "console",
  "rattler_cache",
@@ -3196,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "pixi_git"
 version = "0.0.1"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
  "dashmap",
  "dunce",
@@ -3217,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "pixi_manifest"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
  "console",
  "dunce",
@@ -3250,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "pixi_spec"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
  "dirs 5.0.1",
  "file_url",
@@ -3273,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "pixi_toml"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
  "digest",
  "hex",
@@ -3286,9 +3274,9 @@ dependencies = [
 [[package]]
 name = "pixi_utils"
 version = "0.1.0"
-source = "git+https://github.com/tdejager/pixi?branch=feat/split-source-binary-build-types#93aa37b33de360f0999e5b4d4463df199d213e33"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#a0f8317b047e38365140dd0a8b69579fe6900f1e"
 dependencies = [
- "fd-lock",
+ "async-fd-lock",
  "fs-err",
  "indicatif",
  "itertools 0.13.0",
@@ -3306,6 +3294,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror 2.0.10",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -388,6 +388,19 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "birdcage"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848df95320021558dd6bb4c26de3fe66724cdcbdbbf3fa720150b52b086ae568"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "log",
+ "rustix",
+ "seccompiler",
+]
 
 [[package]]
 name = "bitflags"
@@ -461,9 +474,9 @@ checksum = "2721c3c5a6f0e7f7e607125d963fedeb765f545f67adc9d71ed934693881eb42"
 
 [[package]]
 name = "bstr"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "serde",
@@ -541,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "jobserver",
  "libc",
@@ -595,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "b95dca1b68188a08ca6af9d96a6576150f598824bdb528c1190460c2940a0b48"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -615,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "9ab52925392148efd3f7562f2136a81ffb778076bcc85727c6e020d6dd57cf15"
 dependencies = [
  "anstream",
  "anstyle",
@@ -627,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2e663e3e3bed2d32d065a8404024dad306e699a04263ec59919529f803aee9"
+checksum = "942dc5991a34d8cf58937ec33201856feba9cbceeeab5adf04116ec7c763bff1"
 dependencies = [
  "clap",
 ]
@@ -646,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1081,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1103,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "fancy_display"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3aa823c0c5b5a3ad7df411b1e543d2264267b320"
 dependencies = [
  "console",
 ]
@@ -1127,25 +1140,25 @@ dependencies = [
 
 [[package]]
 name = "file_url"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ad84121770c9766a67e4dd0a96b0467c6a5a2c43e873bf853aeaa6632b687c"
+checksum = "6f1bb23b4220d7fcd5601b2eccdd3609da6d394bdf02b9f485cc81ecbb9413e6"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "percent-encoding",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "typed-path",
  "url",
 ]
 
 [[package]]
 name = "file_url"
-version = "0.2.1"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "0.2.2"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "percent-encoding",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "typed-path",
  "url",
 ]
@@ -1164,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1417,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ab3f32d1d77146981dea5d6b1e8fe31eedcb7013e5e00d6ccd1259a4b4d923"
+checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
 dependencies = [
  "log",
  "plain",
@@ -2022,13 +2035,13 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
 dependencies = [
  "console",
- "lazy_static",
  "linked-hash-map",
+ "once_cell",
  "pest",
  "pest_derive",
  "regex",
@@ -2080,6 +2093,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2219,7 +2241,7 @@ dependencies = [
  "log",
  "secret-service",
  "security-framework 2.11.1",
- "security-framework 3.1.0",
+ "security-framework 3.2.0",
  "windows-sys 0.59.0",
  "zbus",
 ]
@@ -2303,9 +2325,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -2888,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "pep508_rs"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2feee999fa547bacab06a4881bacc74688858b92fa8ef1e206c748b0a76048"
+checksum = "faee7227064121fcadcd2ff788ea26f0d8f2bd23a0574da11eca23bc935bcc05"
 dependencies = [
  "boxcar",
  "indexmap 2.7.0",
@@ -2921,7 +2943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "ucd-trie",
 ]
 
@@ -2961,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.7.0",
@@ -2971,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2981,9 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
@@ -2991,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -3005,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
  "unicase",
@@ -3015,18 +3037,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3035,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -3098,10 +3120,13 @@ dependencies = [
 [[package]]
 name = "pixi_build_types"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3aa823c0c5b5a3ad7df411b1e543d2264267b320"
 dependencies = [
+ "indexmap 2.7.0",
  "rattler_conda_types",
+ "rattler_digest 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
+ "serde_json",
  "serde_with",
  "url",
 ]
@@ -3109,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "pixi_config"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3aa823c0c5b5a3ad7df411b1e543d2264267b320"
 dependencies = [
  "clap",
  "console",
@@ -3125,7 +3150,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "toml_edit",
  "tracing",
  "url",
@@ -3134,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "pixi_consts"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3aa823c0c5b5a3ad7df411b1e543d2264267b320"
 dependencies = [
  "console",
  "rattler_cache",
@@ -3145,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "pixi_git"
 version = "0.0.1"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3aa823c0c5b5a3ad7df411b1e543d2264267b320"
 dependencies = [
  "dashmap",
  "dunce",
@@ -3155,7 +3180,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "serde",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tokio",
  "tracing",
  "url",
@@ -3166,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "pixi_manifest"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3aa823c0c5b5a3ad7df411b1e543d2264267b320"
 dependencies = [
  "console",
  "dunce",
@@ -3190,7 +3215,7 @@ dependencies = [
  "spdx",
  "strsim",
  "strum",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "toml-span",
  "toml_edit",
  "tracing",
@@ -3200,21 +3225,22 @@ dependencies = [
 [[package]]
 name = "pixi_spec"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3aa823c0c5b5a3ad7df411b1e543d2264267b320"
 dependencies = [
  "dirs",
- "file_url 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "file_url 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.13.0",
  "pixi_git",
  "pixi_toml",
  "rattler_conda_types",
- "rattler_digest 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rattler_digest 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde-untagged",
  "serde_with",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "toml-span",
  "toml_edit",
+ "tracing",
  "typed-path",
  "url",
 ]
@@ -3222,7 +3248,7 @@ dependencies = [
 [[package]]
 name = "pixi_toml"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3aa823c0c5b5a3ad7df411b1e543d2264267b320"
 dependencies = [
  "digest",
  "hex",
@@ -3235,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "pixi_utils"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#7e877c3733447c40ca9b7039e20517e8cd591bb6"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3aa823c0c5b5a3ad7df411b1e543d2264267b320"
 dependencies = [
  "fd-lock",
  "fs-err",
@@ -3254,7 +3280,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3403,7 +3429,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tokio",
  "tracing",
 ]
@@ -3422,7 +3448,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3489,8 +3515,8 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.28.9"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "0.28.11"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "anyhow",
  "clap",
@@ -3502,17 +3528,17 @@ dependencies = [
  "humantime",
  "indexmap 2.7.0",
  "indicatif",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "memchr",
  "memmap2",
  "once_cell",
  "parking_lot 0.12.3",
  "rattler_cache",
  "rattler_conda_types",
- "rattler_digest 1.0.4 (git+https://github.com/conda/rattler?branch=main)",
+ "rattler_digest 1.0.5 (git+https://github.com/conda/rattler?branch=main)",
  "rattler_networking",
  "rattler_package_streaming",
- "rattler_shell 0.22.12 (git+https://github.com/conda/rattler?branch=main)",
+ "rattler_shell 0.22.14 (git+https://github.com/conda/rattler?branch=main)",
  "rayon",
  "reflink-copy",
  "regex",
@@ -3521,7 +3547,7 @@ dependencies = [
  "simple_spawn_blocking",
  "smallvec",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tokio",
  "tracing",
  "url",
@@ -3530,8 +3556,8 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.33.2"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#1a88b92c052460b03bcc87b85b2cd173924a507c"
+version = "0.34.1"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#048584ecb5f4093e923b291f85d55b4172e9685e"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3556,7 +3582,7 @@ dependencies = [
  "ignore",
  "indexmap 2.7.0",
  "indicatif",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "marked-yaml",
  "memchr",
@@ -3570,13 +3596,14 @@ dependencies = [
  "rattler",
  "rattler_cache",
  "rattler_conda_types",
- "rattler_digest 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rattler_digest 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rattler_index",
  "rattler_networking",
  "rattler_package_streaming",
  "rattler_redaction",
  "rattler_repodata_gateway",
- "rattler_shell 0.22.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rattler_sandbox",
+ "rattler_shell 0.22.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rattler_solve",
  "rattler_virtual_packages",
  "rayon",
@@ -3597,7 +3624,7 @@ dependencies = [
  "tar",
  "tempfile",
  "terminal_size",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tokio",
  "tokio-util 0.7.13",
  "toml",
@@ -3614,8 +3641,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.1"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "0.3.3"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3625,17 +3652,17 @@ dependencies = [
  "fs4",
  "futures",
  "fxhash",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "parking_lot 0.12.3",
  "rattler_conda_types",
- "rattler_digest 1.0.4 (git+https://github.com/conda/rattler?branch=main)",
+ "rattler_digest 1.0.5 (git+https://github.com/conda/rattler?branch=main)",
  "rattler_networking",
  "rattler_package_streaming",
  "rayon",
  "reqwest",
  "reqwest-middleware",
  "simple_spawn_blocking",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tokio",
  "tracing",
  "url",
@@ -3643,22 +3670,22 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.29.7"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "0.29.9"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "chrono",
  "dirs",
- "file_url 0.2.1 (git+https://github.com/conda/rattler?branch=main)",
+ "file_url 0.2.2 (git+https://github.com/conda/rattler?branch=main)",
  "fs-err",
  "fxhash",
  "glob",
  "hex",
  "indexmap 2.7.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy-regex",
  "nom",
  "purl",
- "rattler_digest 1.0.4 (git+https://github.com/conda/rattler?branch=main)",
+ "rattler_digest 1.0.5 (git+https://github.com/conda/rattler?branch=main)",
  "rattler_macros",
  "rattler_redaction",
  "rayon",
@@ -3672,7 +3699,7 @@ dependencies = [
  "simd-json",
  "smallvec",
  "strum",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tracing",
  "typed-path",
  "url",
@@ -3680,9 +3707,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffd5141cd51f0de194c8c05d97f138d2ea70274636ce911bbdf7dd371942a47"
+checksum = "5f17c58c68c48cb29dcedd76ce2f1d18879df67d89580b1e7dd2cb6ddcf9c2d0"
 dependencies = [
  "blake2",
  "digest",
@@ -3696,8 +3723,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.0.4"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "1.0.5"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "blake2",
  "digest",
@@ -3712,13 +3739,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.20.4"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c1880cb859882d8863dc67d2fe2a89baf4f749df5491a217972c3c1041fc8b"
+checksum = "218921c6a136484b756607bff79f3be724a1bd5fa7d1f9558db5fbf4208c0b04"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
- "rattler_digest 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rattler_digest 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rattler_package_streaming",
  "serde_json",
  "tracing",
@@ -3727,8 +3754,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.4"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "1.0.5"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "quote",
  "syn",
@@ -3736,8 +3763,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.21.9"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "0.21.10"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3749,7 +3776,7 @@ dependencies = [
  "google-cloud-auth",
  "google-cloud-token",
  "http 1.2.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "keyring",
  "netrc-rs",
  "reqwest",
@@ -3757,15 +3784,15 @@ dependencies = [
  "retry-policies",
  "serde",
  "serde_json",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.20"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "0.22.22"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "bzip2 0.5.0",
  "chrono",
@@ -3773,7 +3800,7 @@ dependencies = [
  "futures-util",
  "num_cpus",
  "rattler_conda_types",
- "rattler_digest 1.0.4 (git+https://github.com/conda/rattler?branch=main)",
+ "rattler_digest 1.0.5 (git+https://github.com/conda/rattler?branch=main)",
  "rattler_networking",
  "rattler_redaction",
  "reqwest",
@@ -3781,7 +3808,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tokio",
  "tokio-util 0.7.13",
  "tracing",
@@ -3792,8 +3819,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.5"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "0.1.6"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -3802,8 +3829,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.29"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "0.21.31"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3815,7 +3842,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "dirs",
- "file_url 0.2.1 (git+https://github.com/conda/rattler?branch=main)",
+ "file_url 0.2.2 (git+https://github.com/conda/rattler?branch=main)",
  "fs-err",
  "futures",
  "hex",
@@ -3823,7 +3850,7 @@ dependencies = [
  "http-cache-semantics",
  "humansize",
  "humantime",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "json-patch",
  "libc",
  "md-5",
@@ -3833,11 +3860,12 @@ dependencies = [
  "pin-project-lite",
  "rattler_cache",
  "rattler_conda_types",
- "rattler_digest 1.0.4 (git+https://github.com/conda/rattler?branch=main)",
+ "rattler_digest 1.0.5 (git+https://github.com/conda/rattler?branch=main)",
  "rattler_networking",
  "rattler_redaction",
  "reqwest",
  "reqwest-middleware",
+ "retry-policies",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -3845,7 +3873,7 @@ dependencies = [
  "simple_spawn_blocking",
  "superslice",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tokio",
  "tokio-util 0.7.13",
  "tracing",
@@ -3855,63 +3883,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "rattler_shell"
-version = "0.22.12"
+name = "rattler_sandbox"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e4f21b5783b0ce087d816669a4539add1ce5c076050856e350435a9a27c61f"
+checksum = "9a5c988fcbce1255dfe750bd288f630cefd284768a37c25bf1cb7bf317a07f52"
+dependencies = [
+ "birdcage",
+ "clap",
+ "fs-err",
+ "tokio",
+]
+
+[[package]]
+name = "rattler_shell"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e07fab9fdef5aadae4c4b8d4a08c77fb75f8dc8cad36b0224096bee8d86189d0"
 dependencies = [
  "enum_dispatch",
  "fs-err",
  "indexmap 2.7.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "rattler_conda_types",
  "serde_json",
  "shlex",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tracing",
 ]
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.12"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "0.22.14"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "enum_dispatch",
  "fs-err",
  "indexmap 2.7.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "rattler_conda_types",
  "serde_json",
  "shlex",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tracing",
 ]
 
 [[package]]
 name = "rattler_solve"
-version = "1.3.1"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "1.3.3"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "chrono",
  "futures",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "rattler_conda_types",
- "rattler_digest 1.0.4 (git+https://github.com/conda/rattler?branch=main)",
+ "rattler_digest 1.0.5 (git+https://github.com/conda/rattler?branch=main)",
  "resolvo",
  "serde",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "1.1.15"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+version = "1.1.17"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "archspec",
  "libloading",
@@ -3921,7 +3961,7 @@ dependencies = [
  "rattler_conda_types",
  "regex",
  "serde",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "tracing",
 ]
 
@@ -3996,13 +4036,13 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17400ed684c3a0615932f00c271ae3eea13e47056a1455821995122348ab6438"
+checksum = "8a076c8c302cbd01e62bd6c2f74fc4913c3131aa6fa72dae78047f5535e4fc88"
 dependencies = [
  "cfg-if 1.0.0",
  "rustix",
- "windows 0.58.0",
+ "windows 0.59.0",
 ]
 
 [[package]]
@@ -4143,9 +4183,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fdd3aa47ae0816ce4ec203eba1330e7c96a6760cbfbee5f1d2ca6e768b50f7"
+checksum = "5314eb4b865d39acd1b3cd05eb91b87031bb49fd1278a1bdf8d6680f1389ec29"
 dependencies = [
  "ahash",
  "bitvec",
@@ -4153,7 +4193,7 @@ dependencies = [
  "event-listener",
  "futures",
  "indexmap 2.7.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "petgraph",
  "tracing",
 ]
@@ -4218,9 +4258,9 @@ checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -4252,7 +4292,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.1.0",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -4341,6 +4381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "seccompiler"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6575e3c2b3a0fe2ef3e53855b6a8dead7c29f783da5e123d378c8c6a89017e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "secret-service"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4374,9 +4423,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation 0.10.0",
@@ -4387,9 +4436,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4447,9 +4496,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
@@ -4637,16 +4686,16 @@ dependencies = [
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.0.0"
-source = "git+https://github.com/conda/rattler?branch=main#ea7248693bda08629db150547a92e42dcaa74fd7"
+source = "git+https://github.com/conda/rattler?branch=main#899ab590549a491bb9b40d7b15a0069e6eb38c8d"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -4777,9 +4826,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4917,11 +4966,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.10",
 ]
 
 [[package]]
@@ -4937,9 +4986,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5014,9 +5063,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5032,9 +5081,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5622,12 +5671,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
+ "windows-core 0.59.0",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -5653,15 +5702,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-implement 0.59.0",
+ "windows-interface 0.59.0",
+ "windows-result 0.3.0",
+ "windows-strings 0.3.0",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -5677,9 +5726,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5699,9 +5748,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "cb26fd936d991781ea39e87c3a27285081e3c0da5ca0fcbc02d368cc6f52ff01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5715,7 +5764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result 0.2.0",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5738,6 +5787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34"
+dependencies = [
+ "windows-targets 0.53.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5745,6 +5803,15 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b888f919960b42ea4e11c2f408fadb55f78a9f236d5eef084103c8ce52893491"
+dependencies = [
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -5798,11 +5865,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5818,6 +5901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5828,6 +5917,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5842,10 +5937,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5860,6 +5967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5870,6 +5983,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5884,6 +6003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5896,10 +6021,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.20"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]
@@ -5933,9 +6064,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
 dependencies = [
  "libc",
  "linux-raw-sys",
@@ -6147,7 +6278,7 @@ dependencies = [
  "flate2",
  "indexmap 2.7.0",
  "memchr",
- "thiserror 2.0.9",
+ "thiserror 2.0.10",
  "time",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ rattler_conda_types = { version = "0.29.9", default-features = false }
 rattler_package_streaming = { version = "0.22.22", default-features = false }
 rattler_virtual_packages = { version = "1.1.17", default-features = false }
 
-pixi_build_types = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }
-pixi_consts = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }
-pixi_manifest = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }
-pixi_spec = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }
-pixi_build_type_conversions = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }
+pixi_build_types = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
+pixi_consts = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
+pixi_manifest = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
+pixi_spec = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
+pixi_build_type_conversions = { git = "https://github.com/prefix-dev/pixi", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = "1.37.0"
 tracing-subscriber = "0.3.19"
 url = "2.5.4"
 pyproject-toml = "0.13.4"
+dirs = "6.0.0"
 
 jsonrpc-stdio-server = "18.0.0"
 jsonrpc-http-server = "18.0.0"
@@ -39,8 +40,8 @@ rattler_conda_types = { version = "0.29.9", default-features = false }
 rattler_package_streaming = { version = "0.22.22", default-features = false }
 rattler_virtual_packages = { version = "1.1.17", default-features = false }
 
-pixi_build_types = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }
-pixi_consts = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }
-pixi_manifest = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }
-pixi_spec = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }
-pixi_build_type_conversions = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }
+pixi_build_types = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }
+pixi_consts = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }
+pixi_manifest = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }
+pixi_spec = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }
+pixi_build_type_conversions = { git = "https://github.com/tdejager/pixi", branch = "feat/split-source-binary-build-types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ rattler_conda_types = { version = "0.29.9", default-features = false }
 rattler_package_streaming = { version = "0.22.22", default-features = false }
 rattler_virtual_packages = { version = "1.1.17", default-features = false }
 
-pixi_build_types = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
-pixi_consts = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
-pixi_manifest = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
-pixi_spec = { git = "https://github.com/prefix-dev/pixi", branch = "main" }
+pixi_build_types = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }
+pixi_consts = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }
+pixi_manifest = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }
+pixi_spec = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }
+pixi_build_type_conversions = { git = "https://github.com/tdejager/pixi", branch = "feat/build-type-helper-method" }

--- a/crates/pixi-build/Cargo.toml
+++ b/crates/pixi-build/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true, features = ["macros"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 pyproject-toml = { workspace = true }
+dirs = { workspace = true }
 
 pixi_build_types = { workspace = true }
 pixi_consts = { workspace = true }

--- a/crates/pixi-build/Cargo.toml
+++ b/crates/pixi-build/Cargo.toml
@@ -35,6 +35,7 @@ pixi_build_types = { workspace = true }
 pixi_consts = { workspace = true }
 pixi_manifest = { workspace = true }
 pixi_spec = { workspace = true }
+pixi_build_type_conversions = { workspace = true }
 
 jsonrpc-stdio-server = { workspace = true }
 jsonrpc-http-server = { workspace = true }

--- a/crates/pixi-build/src/bin/pixi-build-cmake/cmake.rs
+++ b/crates/pixi-build/src/bin/pixi-build-cmake/cmake.rs
@@ -28,7 +28,6 @@ use pixi_build_types::{
     },
     BackendCapabilities, CondaPackageMetadata, FrontendCapabilities, PlatformAndVirtualPackages,
 };
-use pixi_manifest::Manifest;
 use rattler_build::{
     build::run_build,
     console_utils::LoggingOutputHandler,
@@ -87,14 +86,8 @@ impl CMakeBuildBackend {
         logging_output_handler: LoggingOutputHandler,
         cache_dir: Option<PathBuf>,
     ) -> miette::Result<Self> {
-        // Load the manifest from the source directory
-        let manifest = Manifest::from_path(manifest_path).with_context(|| {
-            format!("failed to parse manifest from {}", manifest_path.display())
-        })?;
-
         // Determine the root directory of the manifest
-        let manifest_root = manifest
-            .path
+        let manifest_root = manifest_path
             .parent()
             .ok_or_else(|| miette::miette!("the project manifest must reside in a directory"))?
             .to_path_buf();
@@ -111,7 +104,7 @@ impl CMakeBuildBackend {
             .ok_or_else(|| miette::miette!("project model v1 is required"))?;
 
         Ok(Self {
-            manifest_path: manifest.path,
+            manifest_path: manifest_path.to_path_buf(),
             manifest_root,
             project_model: v1,
             _config: config,

--- a/crates/pixi-build/src/bin/pixi-build-cmake/cmake.rs
+++ b/crates/pixi-build/src/bin/pixi-build-cmake/cmake.rs
@@ -122,6 +122,9 @@ impl CMakeBuildBackend {
         BackendCapabilities {
             provides_conda_metadata: Some(true),
             provides_conda_build: Some(true),
+            highest_supported_project_model: Some(
+                pixi_build_types::VersionedProjectModel::highest_version(),
+            ),
         }
     }
 

--- a/crates/pixi-build/src/bin/pixi-build-cmake/cmake.rs
+++ b/crates/pixi-build/src/bin/pixi-build-cmake/cmake.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     collections::BTreeMap,
     path::{Path, PathBuf},
     str::FromStr,
@@ -7,6 +6,7 @@ use std::{
 };
 
 use chrono::Utc;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
 use pixi_build_backend::{
@@ -14,8 +14,10 @@ use pixi_build_backend::{
     protocol::{Protocol, ProtocolFactory},
     utils::TemporaryRenderedRecipe,
     variants::can_be_used_as_variant,
+    AnyVersion, TargetExt,
 };
 use pixi_build_types::{
+    self as pbt,
     procedures::{
         conda_build::{CondaBuildParams, CondaBuildResult, CondaBuiltPackage},
         conda_metadata::{CondaMetadataParams, CondaMetadataResult},
@@ -24,8 +26,7 @@ use pixi_build_types::{
     },
     BackendCapabilities, CondaPackageMetadata, FrontendCapabilities, PlatformAndVirtualPackages,
 };
-use pixi_manifest::{Dependencies, Manifest, PackageManifest, SpecType};
-use pixi_spec::PixiSpec;
+use pixi_manifest::Manifest;
 use rattler_build::{
     build::run_build,
     console_utils::LoggingOutputHandler,
@@ -59,7 +60,7 @@ pub struct CMakeBuildBackend {
     logging_output_handler: LoggingOutputHandler,
     manifest_path: PathBuf,
     manifest_root: PathBuf,
-    package_manifest: PackageManifest,
+    project_model: pbt::ProjectModelV1,
     _config: CMakeBackendConfig,
     cache_dir: Option<PathBuf>,
 }
@@ -79,6 +80,7 @@ impl CMakeBuildBackend {
     /// at the given path.
     pub fn new(
         manifest_path: &Path,
+        project_model: pbt::VersionedProjectModel,
         config: Option<CMakeBackendConfig>,
         logging_output_handler: LoggingOutputHandler,
         cache_dir: Option<PathBuf>,
@@ -95,10 +97,6 @@ impl CMakeBuildBackend {
             .ok_or_else(|| miette::miette!("the project manifest must reside in a directory"))?
             .to_path_buf();
 
-        let Some(package_manifest) = manifest.package else {
-            return Err(miette::miette!("no package manifest found in the manifest"));
-        };
-
         // Read config from the manifest itself if its not provided
         // TODO: I guess this should also be passed over the protocol.
         let config = match config {
@@ -106,10 +104,14 @@ impl CMakeBuildBackend {
             None => CMakeBackendConfig::from_path(manifest_path)?,
         };
 
+        let v1 = project_model
+            .into_v1()
+            .ok_or_else(|| miette::miette!("project model v1 is required"))?;
+
         Ok(Self {
             manifest_path: manifest.path,
             manifest_root,
-            package_manifest,
+            project_model: v1,
             _config: config,
             logging_output_handler,
             cache_dir,
@@ -139,41 +141,38 @@ impl CMakeBuildBackend {
         let mut requirements = Requirements::default();
 
         let targets = self
-            .package_manifest
+            .project_model
             .targets
             .resolve(Some(host_platform))
             .collect_vec();
 
-        let run_dependencies = Dependencies::from(
-            targets
-                .iter()
-                .filter_map(|f| f.dependencies(SpecType::Run).cloned().map(Cow::Owned)),
-        );
+        let run_dependencies = targets
+            .iter()
+            .flat_map(|t| t.run_dependencies.iter())
+            .collect::<IndexMap<&pbt::SourcePackageName, &pbt::PackageSpecV1>>();
 
-        let mut build_dependencies = Dependencies::from(
-            targets
-                .iter()
-                .filter_map(|f| f.dependencies(SpecType::Build).cloned().map(Cow::Owned)),
-        );
+        let host_dependencies = targets
+            .iter()
+            .flat_map(|t| t.host_dependencies.iter())
+            .collect::<IndexMap<&pbt::SourcePackageName, &pbt::PackageSpecV1>>();
 
-        let host_dependencies = Dependencies::from(
-            targets
-                .iter()
-                .filter_map(|f| f.dependencies(SpecType::Host).cloned().map(Cow::Owned)),
+        let mut build_dependencies = targets
+            .iter()
+            .flat_map(|t| t.build_dependencies.iter())
+            .collect::<IndexMap<&pbt::SourcePackageName, &pbt::PackageSpecV1>>(
         );
 
         // Ensure build tools are available in the build dependencies section.
-        for pkg_name in ["cmake", "ninja"] {
+        let build_tools = ["cmake".to_string(), "ninja".to_string()];
+        let any = pbt::PackageSpecV1::any();
+        for pkg_name in build_tools.iter() {
             if build_dependencies.contains_key(pkg_name) {
                 // If the host dependencies already contain the package, we don't need to add it
                 // again.
                 continue;
             }
 
-            build_dependencies.insert(
-                PackageName::from_str(pkg_name).unwrap(),
-                PixiSpec::default(),
-            );
+            build_dependencies.insert(pkg_name, &any);
         }
 
         requirements.build = extract_dependencies(channel_config, build_dependencies, variant)?;
@@ -225,8 +224,9 @@ impl CMakeBuildBackend {
         variant: &BTreeMap<NormalizedKey, String>,
     ) -> miette::Result<Recipe> {
         // Parse the package name from the manifest
-        let package = &self.package_manifest.package;
-        let name = PackageName::from_str(&package.name).into_diagnostic()?;
+        let project_model = &self.project_model;
+
+        let name = PackageName::from_str(&project_model.name).into_diagnostic()?;
 
         let noarch_type = NoArchType::none();
 
@@ -248,7 +248,7 @@ impl CMakeBuildBackend {
             schema_version: 1,
             context: Default::default(),
             package: Package {
-                version: package.version.clone().into(),
+                version: self.project_model.version.clone().into(),
                 name,
             },
             cache: None,
@@ -303,7 +303,7 @@ impl CMakeBuildBackend {
         variant: BTreeMap<NormalizedKey, String>,
     ) -> miette::Result<BuildConfiguration> {
         // Parse the package name from the manifest
-        let name = self.package_manifest.package.name.clone();
+        let name = self.project_model.name.clone();
         let name = PackageName::from_str(&name).into_diagnostic()?;
         // TODO: Setup defaults
         std::fs::create_dir_all(work_directory)
@@ -423,12 +423,17 @@ impl Protocol for CMakeBuildBackend {
 
         // Determine the variant keys that are used in the recipe.
         let used_variants = self
-            .package_manifest
+            .project_model
             .targets
             .resolve(Some(host_platform))
-            .flat_map(|dep| dep.dependencies.values().flatten())
+            .flat_map(|dep| {
+                dep.build_dependencies
+                    .iter()
+                    .chain(dep.run_dependencies.iter())
+                    .chain(dep.host_dependencies.iter())
+            })
             .filter(|(_, spec)| can_be_used_as_variant(spec))
-            .map(|(name, _)| name.into())
+            .map(|(name, _)| name.clone().into())
             .collect();
 
         // Determine the combinations of the used variants.
@@ -617,6 +622,9 @@ impl ProtocolFactory for CMakeBuildBackendFactory {
     ) -> miette::Result<(Self::Protocol, InitializeResult)> {
         let instance = CMakeBuildBackend::new(
             params.manifest_path.as_path(),
+            params
+                .project_model
+                .ok_or_else(|| miette::miette!("project model is required"))?,
             None,
             self.logging_output_handler.clone(),
             params.cache_directory,
@@ -637,6 +645,7 @@ impl ProtocolFactory for CMakeBuildBackendFactory {
 mod tests {
     use std::{collections::BTreeMap, path::PathBuf};
 
+    use pixi_build_type_conversions::to_project_model_v1;
     use pixi_manifest::Manifest;
     use rattler_build::console_utils::LoggingOutputHandler;
     use rattler_conda_types::{ChannelConfig, Platform};
@@ -679,9 +688,12 @@ mod tests {
         std::fs::write(&tmp_manifest, package_with_host_and_build_deps).unwrap();
 
         let manifest = Manifest::from_str(&tmp_manifest, package_with_host_and_build_deps).unwrap();
-
+        let package = manifest.package.unwrap();
+        let channel_config = ChannelConfig::default_with_root_dir(tmp_dir.path().to_path_buf());
+        let project_model = to_project_model_v1(&package, &channel_config).unwrap();
         let cmake_backend = CMakeBuildBackend::new(
             &manifest.path,
+            project_model,
             Some(CMakeBackendConfig::default()),
             LoggingOutputHandler::default(),
             None,

--- a/crates/pixi-build/src/bin/pixi-build-cmake/config.rs
+++ b/crates/pixi-build/src/bin/pixi-build-cmake/config.rs
@@ -1,30 +1,5 @@
-use miette::IntoDiagnostic;
 use serde::Deserialize;
-use std::path::Path;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct CMakeBackendConfig {}
-
-impl CMakeBackendConfig {
-    /// Parse the configuration from a manifest file.
-    pub fn from_path(path: &Path) -> miette::Result<Self> {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "kebab-case")]
-        struct Manifest {
-            #[serde(default)]
-            tool: Tool,
-        }
-
-        #[derive(Default, Deserialize)]
-        #[serde(rename_all = "kebab-case")]
-        struct Tool {
-            #[serde(default)]
-            pixi_build_python: CMakeBackendConfig,
-        }
-
-        let manifest = fs_err::read_to_string(path).into_diagnostic()?;
-        let document: Manifest = toml_edit::de::from_str(&manifest).into_diagnostic()?;
-        Ok(document.tool.pixi_build_python)
-    }
-}

--- a/crates/pixi-build/src/bin/pixi-build-python/config.rs
+++ b/crates/pixi-build/src/bin/pixi-build-python/config.rs
@@ -1,7 +1,5 @@
-use miette::IntoDiagnostic;
 use serde::Deserialize;
 use std::convert::identity;
-use std::path::Path;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -16,26 +14,5 @@ impl PythonBackendConfig {
     /// Whether to build a noarch package or a platform-specific package.
     pub fn noarch(&self) -> bool {
         self.noarch.map_or(true, identity)
-    }
-
-    /// Parse the configuration from a manifest file.
-    pub fn from_path(path: &Path) -> miette::Result<Self> {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "kebab-case")]
-        struct Manifest {
-            #[serde(default)]
-            tool: Tool,
-        }
-
-        #[derive(Default, Deserialize)]
-        #[serde(rename_all = "kebab-case")]
-        struct Tool {
-            #[serde(default)]
-            pixi_build_python: PythonBackendConfig,
-        }
-
-        let manifest = fs_err::read_to_string(path).into_diagnostic()?;
-        let document: Manifest = toml_edit::de::from_str(&manifest).into_diagnostic()?;
-        Ok(document.tool.pixi_build_python)
     }
 }

--- a/crates/pixi-build/src/bin/pixi-build-python/python.rs
+++ b/crates/pixi-build/src/bin/pixi-build-python/python.rs
@@ -29,7 +29,6 @@ use pixi_build_types::{
     },
     BackendCapabilities, CondaPackageMetadata, FrontendCapabilities, PlatformAndVirtualPackages,
 };
-use pixi_manifest::Manifest;
 use pyproject_toml::PyProjectToml;
 use rattler_build::{
     build::run_build,
@@ -92,14 +91,8 @@ impl PythonBuildBackend {
         logging_output_handler: LoggingOutputHandler,
         cache_dir: Option<PathBuf>,
     ) -> miette::Result<Self> {
-        // Load the manifest from the source directory
-        let manifest = Manifest::from_path(manifest_path).with_context(|| {
-            format!("failed to parse manifest from {}", manifest_path.display())
-        })?;
-
         // Determine the root directory of the manifest
-        let manifest_root = manifest
-            .path
+        let manifest_root = manifest_path
             .parent()
             .ok_or_else(|| miette::miette!("the project manifest must reside in a directory"))?
             .to_path_buf();
@@ -131,7 +124,7 @@ impl PythonBuildBackend {
             .ok_or_else(|| miette::miette!("project model v1 is required"))?;
 
         Ok(Self {
-            manifest_path: manifest.path,
+            manifest_path: manifest_path.to_path_buf(),
             manifest_root,
             project_model: v1,
             config,

--- a/crates/pixi-build/src/bin/pixi-build-python/python.rs
+++ b/crates/pixi-build/src/bin/pixi-build-python/python.rs
@@ -206,7 +206,7 @@ impl PythonBuildBackend {
                 continue;
             }
 
-            host_dependencies.insert(&pkg_name, &any);
+            host_dependencies.insert(pkg_name, &any);
         }
 
         requirements.build = extract_dependencies(channel_config, build_dependencies, variant)?;

--- a/crates/pixi-build/src/bin/pixi-build-rattler-build/rattler_build.rs
+++ b/crates/pixi-build/src/bin/pixi-build-rattler-build/rattler_build.rs
@@ -102,6 +102,7 @@ impl RattlerBuildBackend {
         BackendCapabilities {
             provides_conda_metadata: Some(true),
             provides_conda_build: Some(true),
+            highest_supported_project_model: None,
         }
     }
 }
@@ -429,6 +430,7 @@ mod tests {
         let factory = RattlerBuildBackend::factory(LoggingOutputHandler::default())
             .initialize(InitializeParams {
                 manifest_path: recipe,
+                project_model: None,
                 cache_directory: None,
             })
             .await
@@ -463,6 +465,7 @@ mod tests {
         let factory = RattlerBuildBackend::factory(LoggingOutputHandler::default())
             .initialize(InitializeParams {
                 manifest_path: recipe,
+                project_model: None,
                 cache_directory: None,
             })
             .await
@@ -501,6 +504,7 @@ mod tests {
     ) -> miette::Result<RattlerBuildBackend> {
         RattlerBuildBackend::factory(LoggingOutputHandler::default())
             .initialize(InitializeParams {
+                project_model: None,
                 manifest_path: manifest_path.as_ref().to_path_buf(),
                 cache_directory: None,
             })

--- a/crates/pixi-build/src/bin/pixi-build-rattler-build/rattler_build.rs
+++ b/crates/pixi-build/src/bin/pixi-build-rattler-build/rattler_build.rs
@@ -431,6 +431,7 @@ mod tests {
             .initialize(InitializeParams {
                 manifest_path: recipe,
                 project_model: None,
+                configuration: None,
                 cache_directory: None,
             })
             .await
@@ -466,6 +467,7 @@ mod tests {
             .initialize(InitializeParams {
                 manifest_path: recipe,
                 project_model: None,
+                configuration: None,
                 cache_directory: None,
             })
             .await
@@ -506,6 +508,7 @@ mod tests {
             .initialize(InitializeParams {
                 project_model: None,
                 manifest_path: manifest_path.as_ref().to_path_buf(),
+                configuration: None,
                 cache_directory: None,
             })
             .await

--- a/crates/pixi-build/src/build_types_ext.rs
+++ b/crates/pixi-build/src/build_types_ext.rs
@@ -1,0 +1,63 @@
+//! This module mimics some of the functions find in pixi that works with the data types
+//! there but work with the project model types instead.
+use itertools::Either;
+use pixi_build_types as pbt;
+use rattler_conda_types::Platform;
+
+pub trait TargetSelectorExt {
+    /// Does the target selector match the platform?
+    fn matches(&self, platform: Platform) -> bool;
+}
+
+impl TargetSelectorExt for pbt::TargetSelectorV1 {
+    fn matches(&self, platform: Platform) -> bool {
+        match self {
+            pbt::TargetSelectorV1::Platform(p) => p == &platform.to_string(),
+            pbt::TargetSelectorV1::Linux => platform.is_linux(),
+            pbt::TargetSelectorV1::Unix => platform.is_unix(),
+            pbt::TargetSelectorV1::Win => platform.is_windows(),
+            pbt::TargetSelectorV1::MacOs => platform.is_osx(),
+        }
+    }
+}
+
+/// Extends the  type with additional functionality.
+pub trait TargetExt<'a, Selector: TargetSelectorExt, Target>
+where
+    Selector: 'a,
+    Target: 'a,
+{
+    /// Returns the default target.
+    fn default_target(&self) -> &Target;
+
+    /// Returns all targets
+    fn targets(&'a self) -> impl Iterator<Item = (&'a Selector, &'a Target)>;
+
+    /// Resolve the target for the given platform.
+    fn resolve(&'a self, platform: Option<Platform>) -> impl Iterator<Item = &'a Target> {
+        if let Some(platform) = platform {
+            let iter = std::iter::once(self.default_target()).chain(self.targets().filter_map(
+                move |(selector, target)| {
+                    if selector.matches(platform) {
+                        Some(target)
+                    } else {
+                        None
+                    }
+                },
+            ));
+            Either::Right(iter)
+        } else {
+            Either::Left(std::iter::once(self.default_target()))
+        }
+    }
+}
+
+impl<'a> TargetExt<'a, pbt::TargetSelectorV1, pbt::TargetV1> for pbt::TargetsV1 {
+    fn default_target(&self) -> &pbt::TargetV1 {
+        &self.default_target
+    }
+
+    fn targets(&'a self) -> impl Iterator<Item = (&'a pbt::TargetSelectorV1, &'a pbt::TargetV1)> {
+        self.targets.iter()
+    }
+}

--- a/crates/pixi-build/src/build_types_ext.rs
+++ b/crates/pixi-build/src/build_types_ext.rs
@@ -1,40 +1,33 @@
 //! This module mimics some of the functions find in pixi that works with the data types
 //! there but work with the project model types instead.
+//!
+//! This makes it easier when devoloping new backends that need to work with the project model.
+use std::sync::Arc;
+
 use itertools::Either;
 use pixi_build_types as pbt;
-use rattler_conda_types::Platform;
+use rattler_conda_types::{Channel, NamelessMatchSpec, Platform};
 
 pub trait TargetSelectorExt {
     /// Does the target selector match the platform?
     fn matches(&self, platform: Platform) -> bool;
 }
 
-impl TargetSelectorExt for pbt::TargetSelectorV1 {
-    fn matches(&self, platform: Platform) -> bool {
-        match self {
-            pbt::TargetSelectorV1::Platform(p) => p == &platform.to_string(),
-            pbt::TargetSelectorV1::Linux => platform.is_linux(),
-            pbt::TargetSelectorV1::Unix => platform.is_unix(),
-            pbt::TargetSelectorV1::Win => platform.is_windows(),
-            pbt::TargetSelectorV1::MacOs => platform.is_osx(),
-        }
-    }
-}
-
 /// Extends the  type with additional functionality.
-pub trait TargetExt<'a, Selector: TargetSelectorExt, Target>
-where
-    Selector: 'a,
-    Target: 'a,
-{
+pub trait TargetExt<'a> {
+    /// The selector, in pixi this is something like `[target.linux-64]
+    type Selector: TargetSelectorExt + 'a;
+    /// The target it is resolving to
+    type Target: 'a;
+
     /// Returns the default target.
-    fn default_target(&self) -> &Target;
+    fn default_target(&self) -> &Self::Target;
 
     /// Returns all targets
-    fn targets(&'a self) -> impl Iterator<Item = (&'a Selector, &'a Target)>;
+    fn targets(&'a self) -> impl Iterator<Item = (&'a Self::Selector, &'a Self::Target)>;
 
     /// Resolve the target for the given platform.
-    fn resolve(&'a self, platform: Option<Platform>) -> impl Iterator<Item = &'a Target> {
+    fn resolve(&'a self, platform: Option<Platform>) -> impl Iterator<Item = &'a Self::Target> {
         if let Some(platform) = platform {
             let iter = std::iter::once(self.default_target()).chain(self.targets().filter_map(
                 move |(selector, target)| {
@@ -52,7 +45,52 @@ where
     }
 }
 
-impl<'a> TargetExt<'a, pbt::TargetSelectorV1, pbt::TargetV1> for pbt::TargetsV1 {
+/// Get the * version for the version type, that is currently being used
+pub trait AnyVersion {
+    fn any() -> Self;
+}
+
+pub trait BinarySpecExt {
+    fn to_nameless(&self) -> NamelessMatchSpec;
+}
+
+impl BinarySpecExt for pbt::BinaryPackageSpecV1 {
+    fn to_nameless(&self) -> NamelessMatchSpec {
+        NamelessMatchSpec {
+            version: self.version.clone(),
+            build: self.build.clone(),
+            build_number: self.build_number.clone(),
+            file_name: self.file_name.clone(),
+            channel: self
+                .channel
+                .as_ref()
+                .map(|url| Arc::new(Channel::from_url(url.clone()))),
+            subdir: self.subdir.clone(),
+            md5: self.md5.as_ref().map(|m| m.0.clone()),
+            sha256: self.sha256.as_ref().map(|s| s.0.clone()),
+            namespace: None,
+            url: None,
+        }
+    }
+}
+
+// === Below here are the implementations for v1 ===
+impl TargetSelectorExt for pbt::TargetSelectorV1 {
+    fn matches(&self, platform: Platform) -> bool {
+        match self {
+            pbt::TargetSelectorV1::Platform(p) => p == &platform.to_string(),
+            pbt::TargetSelectorV1::Linux => platform.is_linux(),
+            pbt::TargetSelectorV1::Unix => platform.is_unix(),
+            pbt::TargetSelectorV1::Win => platform.is_windows(),
+            pbt::TargetSelectorV1::MacOs => platform.is_osx(),
+        }
+    }
+}
+
+impl<'a> TargetExt<'a> for pbt::TargetsV1 {
+    type Selector = pbt::TargetSelectorV1;
+    type Target = pbt::TargetV1;
+
     fn default_target(&self) -> &pbt::TargetV1 {
         &self.default_target
     }
@@ -61,3 +99,11 @@ impl<'a> TargetExt<'a, pbt::TargetSelectorV1, pbt::TargetV1> for pbt::TargetsV1 
         self.targets.iter()
     }
 }
+
+impl AnyVersion for pbt::PackageSpecV1 {
+    fn any() -> Self {
+        pbt::PackageSpecV1::Binary(rattler_conda_types::VersionSpec::Any.into())
+    }
+}
+
+// == end of v1 implementations ==

--- a/crates/pixi-build/src/build_types_ext.rs
+++ b/crates/pixi-build/src/build_types_ext.rs
@@ -1,4 +1,4 @@
-//! This module mimics some of the functions find in pixi that works with the data types
+//! This module mimics some of the functions found in pixi that works with the data types
 //! there but work with the project model types instead.
 //!
 //! This makes it easier when devoloping new backends that need to work with the project model.

--- a/crates/pixi-build/src/build_types_ext.rs
+++ b/crates/pixi-build/src/build_types_ext.rs
@@ -66,8 +66,8 @@ impl BinarySpecExt for pbt::BinaryPackageSpecV1 {
                 .as_ref()
                 .map(|url| Arc::new(Channel::from_url(url.clone()))),
             subdir: self.subdir.clone(),
-            md5: self.md5.as_ref().map(|m| m.0.clone()),
-            sha256: self.sha256.as_ref().map(|s| s.0.clone()),
+            md5: self.md5.as_ref().map(|m| m.0),
+            sha256: self.sha256.as_ref().map(|s| s.0),
             namespace: None,
             url: None,
         }

--- a/crates/pixi-build/src/cli.rs
+++ b/crates/pixi-build/src/cli.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use clap::{Parser, Subcommand};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use miette::{Context, IntoDiagnostic};
+use pixi_build_type_conversions::to_project_model_v1;
 use pixi_build_types::{
     procedures::{
         conda_build::CondaBuildParams,
@@ -10,7 +11,8 @@ use pixi_build_types::{
         initialize::InitializeParams,
         negotiate_capabilities::NegotiateCapabilitiesParams,
     },
-    ChannelConfiguration, FrontendCapabilities, PlatformAndVirtualPackages,
+    BackendCapabilities, ChannelConfiguration, FrontendCapabilities, PlatformAndVirtualPackages,
+    VersionedProjectModel,
 };
 use rattler_build::console_utils::{get_default_env_filter, LoggingOutputHandler};
 use rattler_conda_types::{ChannelConfig, GenericVirtualPackage, Platform};
@@ -27,6 +29,7 @@ use crate::{
 #[allow(missing_docs)]
 #[derive(Parser)]
 pub struct App {
+    /// The subcommand to run.
     #[clap(subcommand)]
     command: Option<Commands>,
 
@@ -59,6 +62,7 @@ pub enum Commands {
     Capabilities,
 }
 
+/// Run the sever on the specified port or over stdin/stdout.
 async fn run_server<T: ProtocolFactory>(port: Option<u16>, protocol: T) -> miette::Result<()> {
     let server = Server::new(protocol);
     if let Some(port) = port {
@@ -68,6 +72,7 @@ async fn run_server<T: ProtocolFactory>(port: Option<u16>, protocol: T) -> miett
     }
 }
 
+/// Run the main CLI.
 pub async fn main<T: ProtocolFactory, F: FnOnce(LoggingOutputHandler) -> T>(
     factory: F,
 ) -> miette::Result<()> {
@@ -83,7 +88,29 @@ pub async fn main<T: ProtocolFactory, F: FnOnce(LoggingOutputHandler) -> T>(
 
     match args.command {
         None => run_server(args.http_port, factory).await,
-        Some(Commands::Capabilities) => capabilities::<T>().await,
+        Some(Commands::Capabilities) => {
+            let backend_capabilities = capabilities::<T>().await?;
+            eprintln!(
+                "Supports conda metadata: {}",
+                backend_capabilities
+                    .provides_conda_metadata
+                    .unwrap_or_default()
+            );
+            eprintln!(
+                "Supports conda build: {}",
+                backend_capabilities
+                    .provides_conda_build
+                    .unwrap_or_default()
+            );
+            eprintln!(
+                "Highest project model: {}",
+                backend_capabilities
+                    .highest_supported_project_model
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| String::from("None"))
+            );
+            Ok(())
+        }
         Some(Commands::CondaBuild { manifest_path }) => build(factory, &manifest_path).await,
         Some(Commands::GetCondaMetadata {
             manifest_path,
@@ -96,8 +123,47 @@ pub async fn main<T: ProtocolFactory, F: FnOnce(LoggingOutputHandler) -> T>(
     }
 }
 
-async fn get_conda_metadata(
-    factory: impl ProtocolFactory,
+/// Convert manifest to project model
+fn project_model_v1(manifest_path: &Path) -> miette::Result<Option<VersionedProjectModel>> {
+    // Load the manifest
+    let manifest = pixi_manifest::Manifest::from_path(manifest_path)?;
+    let package = manifest.package;
+    // This can be null in the rattler-build backend
+    Ok(package.map(|manifest| to_project_model_v1(&manifest)))
+}
+
+/// Negotiate the capabilities of the backend and initalize the backend.
+async fn initalize<T: ProtocolFactory>(
+    factory: T,
+    manifest_path: &Path,
+) -> miette::Result<T::Protocol> {
+    // Negotiate the capabilities of the backend.
+    let capabilites = capabilities::<T>().await?;
+    let project_model = project_model_v1(manifest_path)?;
+
+    // Check if the project model is required
+    // and if it is not present, return an error.
+    if capabilites.highest_supported_project_model.is_some() && project_model.is_none() {
+        miette::bail!(
+            "Could not extract 'project_model' from: {}, while it is required",
+            manifest_path.display()
+        );
+    }
+
+    // Initialize the backend
+    let (protocol, _initialize_result) = factory
+        .initialize(InitializeParams {
+            manifest_path: manifest_path.to_path_buf(),
+            project_model,
+            cache_directory: None,
+        })
+        .await?;
+    Ok(protocol)
+}
+
+/// Frontend implementation for getting conda metadata.
+async fn get_conda_metadata<T: ProtocolFactory>(
+    factory: T,
     manifest_path: &Path,
     host_platform: Option<Platform>,
 ) -> miette::Result<CondaMetadataResult> {
@@ -108,13 +174,7 @@ async fn get_conda_metadata(
             .to_path_buf(),
     );
 
-    let (protocol, _initialize_result) = factory
-        .initialize(InitializeParams {
-            manifest_path: manifest_path.to_path_buf(),
-            cache_directory: None,
-        })
-        .await?;
-
+    let protocol = initalize(factory, manifest_path).await?;
     let virtual_packages: Vec<_> = VirtualPackage::detect(&VirtualPackageOverrides::from_env())
         .into_diagnostic()?
         .into_iter()
@@ -142,28 +202,18 @@ async fn get_conda_metadata(
         .await
 }
 
-async fn capabilities<Factory: ProtocolFactory>() -> miette::Result<()> {
+/// Returns the capabilities of the backend.
+async fn capabilities<Factory: ProtocolFactory>() -> miette::Result<BackendCapabilities> {
     let result = Factory::negotiate_capabilities(NegotiateCapabilitiesParams {
         capabilities: FrontendCapabilities {},
     })
     .await?;
 
-    eprintln!(
-        "Supports conda metadata: {}",
-        result
-            .capabilities
-            .provides_conda_metadata
-            .unwrap_or_default()
-    );
-    eprintln!(
-        "Supports conda build: {}",
-        result.capabilities.provides_conda_build.unwrap_or_default()
-    );
-
-    Ok(())
+    Ok(result.capabilities)
 }
 
-async fn build(factory: impl ProtocolFactory, manifest_path: &Path) -> miette::Result<()> {
+/// Frontend implementation for building a conda package.
+async fn build<T: ProtocolFactory>(factory: T, manifest_path: &Path) -> miette::Result<()> {
     let channel_config = ChannelConfig::default_with_root_dir(
         manifest_path
             .parent()
@@ -171,13 +221,7 @@ async fn build(factory: impl ProtocolFactory, manifest_path: &Path) -> miette::R
             .to_path_buf(),
     );
 
-    let (protocol, _initialize_result) = factory
-        .initialize(InitializeParams {
-            manifest_path: manifest_path.to_path_buf(),
-            cache_directory: None,
-        })
-        .await?;
-
+    let protocol = initalize(factory, manifest_path).await?;
     let work_dir = TempDir::new_in(".")
         .into_diagnostic()
         .context("failed to create a temporary directory in the current directory")?;

--- a/crates/pixi-build/src/cli.rs
+++ b/crates/pixi-build/src/cli.rs
@@ -12,7 +12,7 @@ use pixi_build_types::{
         negotiate_capabilities::NegotiateCapabilitiesParams,
     },
     BackendCapabilities, ChannelConfiguration, FrontendCapabilities, PlatformAndVirtualPackages,
-    VersionedProjectModel,
+    ProjectModelV1,
 };
 use rattler_build::console_utils::{get_default_env_filter, LoggingOutputHandler};
 use rattler_conda_types::{ChannelConfig, GenericVirtualPackage, Platform};
@@ -127,7 +127,7 @@ pub async fn main<T: ProtocolFactory, F: FnOnce(LoggingOutputHandler) -> T>(
 fn project_model_v1(
     manifest_path: &Path,
     channel_config: &ChannelConfig,
-) -> miette::Result<Option<VersionedProjectModel>> {
+) -> miette::Result<Option<ProjectModelV1>> {
     // Load the manifest
     let manifest = pixi_manifest::Manifest::from_path(manifest_path)?;
     let package = manifest.package;
@@ -166,8 +166,9 @@ async fn initialize<T: ProtocolFactory>(
     let (protocol, _initialize_result) = factory
         .initialize(InitializeParams {
             manifest_path: manifest_path.to_path_buf(),
-            project_model,
+            project_model: project_model.map(Into::into),
             cache_directory: None,
+            configuration: None,
         })
         .await?;
     Ok(protocol)

--- a/crates/pixi-build/src/cli.rs
+++ b/crates/pixi-build/src/cli.rs
@@ -138,13 +138,13 @@ fn project_model_v1(
     }))
 }
 
-/// Negotiate the capabilities of the backend and initalize the backend.
-async fn initalize<T: ProtocolFactory>(
+/// Negotiate the capabilities of the backend and initialize the backend.
+async fn initialize<T: ProtocolFactory>(
     factory: T,
     manifest_path: &Path,
 ) -> miette::Result<T::Protocol> {
     // Negotiate the capabilities of the backend.
-    let capabilites = capabilities::<T>().await?;
+    let capabilities = capabilities::<T>().await?;
     let channel_config = ChannelConfig::default_with_root_dir(
         manifest_path
             .parent()
@@ -155,7 +155,7 @@ async fn initalize<T: ProtocolFactory>(
 
     // Check if the project model is required
     // and if it is not present, return an error.
-    if capabilites.highest_supported_project_model.is_some() && project_model.is_none() {
+    if capabilities.highest_supported_project_model.is_some() && project_model.is_none() {
         miette::bail!(
             "Could not extract 'project_model' from: {}, while it is required",
             manifest_path.display()
@@ -186,7 +186,7 @@ async fn get_conda_metadata<T: ProtocolFactory>(
             .to_path_buf(),
     );
 
-    let protocol = initalize(factory, manifest_path).await?;
+    let protocol = initialize(factory, manifest_path).await?;
     let virtual_packages: Vec<_> = VirtualPackage::detect(&VirtualPackageOverrides::from_env())
         .into_diagnostic()?
         .into_iter()
@@ -233,7 +233,7 @@ async fn build<T: ProtocolFactory>(factory: T, manifest_path: &Path) -> miette::
             .to_path_buf(),
     );
 
-    let protocol = initalize(factory, manifest_path).await?;
+    let protocol = initialize(factory, manifest_path).await?;
     let work_dir = TempDir::new_in(".")
         .into_diagnostic()
         .context("failed to create a temporary directory in the current directory")?;

--- a/crates/pixi-build/src/dependencies.rs
+++ b/crates/pixi-build/src/dependencies.rs
@@ -71,7 +71,7 @@ impl<'a> MatchspecExtractor<'a> {
         for (name, spec) in dependencies.into_iter() {
             let name = PackageName::from_str(name.as_str()).into_diagnostic()?;
             // If we have a variant override, we should use that instead of the spec.
-            if can_be_used_as_variant(&spec) {
+            if can_be_used_as_variant(spec) {
                 if let Some(variant_value) = self
                     .variant
                     .as_ref()
@@ -105,7 +105,7 @@ impl<'a> MatchspecExtractor<'a> {
                 pbt::PackageSpecV1::Source(source_spec) => match source_spec {
                     pbt::SourcePackageSpecV1::Path(path) => {
                         let path =
-                            resolve_path(&Path::new(&path.path), root_dir).ok_or_else(|| {
+                            resolve_path(Path::new(&path.path), root_dir).ok_or_else(|| {
                                 miette::miette!("failed to resolve home dir for: {}", path.path)
                             })?;
                         if self.ignore_self && path.as_path() == root_dir.as_path() {

--- a/crates/pixi-build/src/dependencies.rs
+++ b/crates/pixi-build/src/dependencies.rs
@@ -1,21 +1,38 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
-use itertools::Either;
 use miette::{Context, IntoDiagnostic};
-use pixi_manifest::{CondaDependencies, Dependencies};
-use pixi_spec::{PixiSpec, SourceSpec};
+use pixi_build_types as pbt;
 use rattler_build::{recipe::parser::Dependency, NormalizedKey};
 use rattler_conda_types::{
     ChannelConfig, MatchSpec, NamelessMatchSpec, PackageName, ParseStrictness::Strict,
 };
 
-use crate::variants::can_be_used_as_variant;
+use crate::{build_types_ext::BinarySpecExt, variants::can_be_used_as_variant};
 
 /// A helper struct to extract match specs from a manifest.
 pub struct MatchspecExtractor<'a> {
     channel_config: &'a ChannelConfig,
     variant: Option<&'a BTreeMap<NormalizedKey, String>>,
     ignore_self: bool,
+}
+
+/// Resolves the path relative to `root_dir`. If the path is absolute,
+/// it is returned verbatim.
+///
+/// May return an error if the path is prefixed with `~` and the home
+/// directory is undefined.
+fn resolve_path(path: &Path, root_dir: impl AsRef<Path>) -> Option<PathBuf> {
+    if path.is_absolute() {
+        Some(PathBuf::from(path))
+    } else if let Ok(user_path) = path.strip_prefix("~/") {
+        dirs::home_dir().map(|h| h.join(user_path))
+    } else {
+        Some(root_dir.as_ref().join(path))
+    }
 }
 
 impl<'a> MatchspecExtractor<'a> {
@@ -45,10 +62,14 @@ impl<'a> MatchspecExtractor<'a> {
     }
 
     /// Extracts match specs from the given set of dependencies.
-    pub fn extract(&self, dependencies: CondaDependencies) -> miette::Result<Vec<MatchSpec>> {
+    pub fn extract<'b>(
+        &self,
+        dependencies: impl IntoIterator<Item = (&'b pbt::SourcePackageName, &'b pbt::PackageSpecV1)>,
+    ) -> miette::Result<Vec<MatchSpec>> {
         let root_dir = &self.channel_config.root_dir;
         let mut specs = Vec::new();
-        for (name, spec) in dependencies.into_specs() {
+        for (name, spec) in dependencies.into_iter() {
+            let name = PackageName::from_str(name.as_str()).into_diagnostic()?;
             // If we have a variant override, we should use that instead of the spec.
             if can_be_used_as_variant(&spec) {
                 if let Some(variant_value) = self
@@ -64,36 +85,48 @@ impl<'a> MatchspecExtractor<'a> {
                 }
             }
 
-            let source_or_binary = spec.into_source_or_binary();
-            let match_spec = match source_or_binary {
-                Either::Left(SourceSpec::Path(path))
-                    if self.ignore_self
-                        && path
-                            .resolve(root_dir)
-                            .map_or(false, |path| path.as_path() == root_dir) =>
-                {
-                    // Skip source dependencies that point to the root directory. That would
-                    // be a self reference.
-                    continue;
-                }
-                Either::Left(_) => {
-                    // All other source dependencies are not yet supported.
-                    return Err(miette::miette!(
-                        "recursive source dependencies are not yet supported"
-                    ));
-                }
-                Either::Right(binary) => {
-                    let nameless_spec = binary
-                        .try_into_nameless_match_spec(self.channel_config)
-                        .into_diagnostic()?;
-                    if nameless_spec.version == Some("*".parse().unwrap()) {
+            // Match on supported packages
+            let match_spec = match spec {
+                pbt::PackageSpecV1::Binary(binary_spec) => {
+                    let match_spec = if binary_spec.version == Some("*".parse().unwrap()) {
                         // Skip dependencies with wildcard versions.
-                        name.as_normalized().to_string().parse().unwrap()
+                        name.as_normalized()
+                            .to_string()
+                            .parse::<MatchSpec>()
+                            .into_diagnostic()
                     } else {
-                        MatchSpec::from_nameless(nameless_spec, Some(name))
-                    }
+                        Ok(MatchSpec::from_nameless(
+                            binary_spec.to_nameless(),
+                            Some(name),
+                        ))
+                    };
+                    match_spec
                 }
-            };
+                pbt::PackageSpecV1::Source(source_spec) => match source_spec {
+                    pbt::SourcePackageSpecV1::Path(path) => {
+                        let path =
+                            resolve_path(&Path::new(&path.path), root_dir).ok_or_else(|| {
+                                miette::miette!("failed to resolve home dir for: {}", path.path)
+                            })?;
+                        if self.ignore_self && path.as_path() == root_dir.as_path() {
+                            // Skip source dependencies that point to the root directory. That would
+                            // be a self reference.
+                            continue;
+                        } else {
+                            // All other source dependencies are not yet supported.
+                            return Err(miette::miette!(
+                                "recursive source dependencies are not yet supported"
+                            ));
+                        }
+                    }
+                    _ => {
+                        // All other source dependencies are not yet supported.
+                        return Err(miette::miette!(
+                            "recursive source dependencies are not yet supported"
+                        ));
+                    }
+                },
+            }?;
 
             specs.push(match_spec);
         }
@@ -102,9 +135,9 @@ impl<'a> MatchspecExtractor<'a> {
     }
 }
 
-pub fn extract_dependencies(
+pub fn extract_dependencies<'a>(
     channel_config: &ChannelConfig,
-    dependencies: Dependencies<PackageName, PixiSpec>,
+    dependencies: impl IntoIterator<Item = (&'a pbt::SourcePackageName, &'a pbt::PackageSpecV1)>,
     variant: &BTreeMap<NormalizedKey, String>,
 ) -> miette::Result<Vec<Dependency>> {
     Ok(MatchspecExtractor::new(channel_config)

--- a/crates/pixi-build/src/lib.rs
+++ b/crates/pixi-build/src/lib.rs
@@ -10,4 +10,4 @@ pub mod tools;
 pub mod utils;
 pub mod variants;
 
-pub use build_types_ext::{TargetExt, TargetSelectorExt};
+pub use build_types_ext::{AnyVersion, TargetExt, TargetSelectorExt};

--- a/crates/pixi-build/src/lib.rs
+++ b/crates/pixi-build/src/lib.rs
@@ -2,9 +2,12 @@ pub mod cli;
 pub mod protocol;
 pub mod server;
 
+mod build_types_ext;
 mod consts;
 pub mod dependencies;
 pub mod manifest_ext;
 pub mod tools;
 pub mod utils;
 pub mod variants;
+
+pub use build_types_ext::{TargetExt, TargetSelectorExt};

--- a/crates/pixi-build/src/variants.rs
+++ b/crates/pixi-build/src/variants.rs
@@ -1,13 +1,12 @@
-use pixi_spec::{DetailedSpec, PixiSpec};
+use pixi_build_types as pbt;
 use rattler_conda_types::VersionSpec;
 
 /// Returns true if the specified [`PixiSpec`] is a valid variant spec.
 ///
 /// At the moment, a spec that allows any version is considered a variant spec.
-pub fn can_be_used_as_variant(spec: &PixiSpec) -> bool {
+pub fn can_be_used_as_variant(spec: &pbt::PackageSpecV1) -> bool {
     match spec {
-        PixiSpec::Version(version)
-        | PixiSpec::DetailedVersion(DetailedSpec {
+        pbt::PackageSpecV1::Binary(pbt::BinaryPackageSpecV1 {
             version: Some(version),
             build: None,
             build_number: None,

--- a/pixi.lock
+++ b/pixi.lock
@@ -41,13 +41,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.1.0-h5d3d1c9_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.1.0-hcba0ae0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-hc0a3c3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
@@ -55,8 +57,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.4-h194c7f8_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.80.1-h0a17960_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.80.1-h2c6d0dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.81.0-h1a8d7c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.81.0-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
@@ -72,8 +74,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.4-h37a9e06_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.80.1-h6c54e5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.80.1-h38e4360_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.81.0-h6c54e5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.81.0-h38e4360_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
@@ -88,8 +90,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.4-h30c5eda_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.80.1-h4ff7c5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.80.1-hf6ec828_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.81.0-h4ff7c5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.81.0-hf6ec828_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
@@ -102,8 +104,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.4-h889d299_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.80.1-hf8d6059_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.80.1-h17fc481_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.81.0-hf8d6059_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.81.0-h17fc481_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
@@ -401,13 +403,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.1.0-h5d3d1c9_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.1.0-hcba0ae0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-hc0a3c3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
@@ -418,8 +422,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.4-h194c7f8_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.80.1-h0a17960_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.80.1-h2c6d0dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.81.0-h1a8d7c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.81.0-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
@@ -442,8 +446,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.4-h37a9e06_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.80.1-h6c54e5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.80.1-h38e4360_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.81.0-h6c54e5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.81.0-h38e4360_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
@@ -465,8 +469,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.4-h30c5eda_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.80.1-h4ff7c5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.80.1-hf6ec828_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.81.0-h4ff7c5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.81.0-hf6ec828_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
@@ -486,8 +490,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.4-h889d299_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.80.1-hf8d6059_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.80.1-h17fc481_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.81.0-hf8d6059_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.81.0-h17fc481_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
@@ -1029,6 +1033,8 @@ packages:
   constrains:
   - libgomp 14.2.0 h77fa898_1
   - libgcc-ng ==14.2.0=*_1
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 848745
@@ -1068,6 +1074,8 @@ packages:
   md5: e39480b9ca41323497b05492a63bc35b
   depends:
   - libgcc 14.2.0 h77fa898_1
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 54142
@@ -1095,6 +1103,8 @@ packages:
   md5: cc3573974587f12dda90d96e3e55a702
   depends:
   - _libgcc_mutex 0.1 conda_forge
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 460992
@@ -1246,6 +1256,8 @@ packages:
   md5: 234a5554c53625688d51062645337328
   depends:
   - libgcc 14.2.0 h77fa898_1
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 3893695
@@ -1268,6 +1280,17 @@ packages:
   license_family: GPL
   size: 3881307
   timestamp: 1719538923443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  arch: x86_64
+  platform: linux
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
@@ -2094,8 +2117,6 @@ packages:
   - patchelf
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 11222562
@@ -2107,8 +2128,6 @@ packages:
   - __osx >=10.13
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 9573725
@@ -2120,8 +2139,6 @@ packages:
   - __osx >=11.0
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 9170986
@@ -2133,8 +2150,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 8927539
@@ -2324,91 +2339,99 @@ packages:
   license_family: MIT
   size: 6314546
   timestamp: 1723151403766
-- conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.80.1-h0a17960_0.conda
-  sha256: 7058519747d4b81f3cab23a0d6b4326c80879d38b2a0bf11cade52fc59980b8f
-  md5: dba7ad0d2f707fee5e85c6a19042fdb4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.81.0-h1a8d7c4_0.conda
+  sha256: 0620c44414d140f63e215b8555770acb94e473787f84cb1ab051bb6ebd3a808f
+  md5: 0e4d3f6598c7b770b1ac73ca8689c300
   depends:
   - __glibc >=2.17,<3.0.a0
   - gcc_impl_linux-64
-  - libgcc-ng >=12
+  - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
-  - rust-std-x86_64-unknown-linux-gnu 1.80.1 h2c6d0dc_0
+  - rust-std-x86_64-unknown-linux-gnu 1.81.0 h2c6d0dc_0
   - sysroot_linux-64 >=2.17
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  size: 198885602
-  timestamp: 1723153698032
-- conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.80.1-h6c54e5d_0.conda
-  sha256: 8e799c550545a41baef23a543ffd87620cf67c0afd3494ea40b6081cbf8aabe7
-  md5: ecf36b937ded5c641039161f7f5c7f64
+  size: 200303283
+  timestamp: 1726504386467
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.81.0-h6c54e5d_0.conda
+  sha256: 84e3131a0441e2694849bd0c8de3fd3eac2a1b4e3ae49f37114c2b4c876d4bec
+  md5: ae4382936ab0a7ba617410f3371dba8c
   depends:
-  - rust-std-x86_64-apple-darwin 1.80.1 h38e4360_0
+  - rust-std-x86_64-apple-darwin 1.81.0 h38e4360_0
+  arch: x86_64
+  platform: osx
   license: MIT
   license_family: MIT
-  size: 202606989
-  timestamp: 1723154998091
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.80.1-h4ff7c5d_0.conda
-  sha256: 5b296bb663be4c10bf3d07eaaa69c3c5856bd198152a775404e161f6780236bb
-  md5: 76d236abc95f2d77f7a3c16f1b565b3e
+  size: 205216960
+  timestamp: 1726505981140
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.81.0-h4ff7c5d_0.conda
+  sha256: aa6dffbf4b6441512f9dcce572913b2cfff2a2f71b0ffe9b29c04efa4e1e15d7
+  md5: 9421a9205351eb673c57af9e491dc2bf
   depends:
-  - rust-std-aarch64-apple-darwin 1.80.1 hf6ec828_0
+  - rust-std-aarch64-apple-darwin 1.81.0 hf6ec828_0
+  arch: arm64
+  platform: osx
   license: MIT
   license_family: MIT
-  size: 197866703
-  timestamp: 1723155024117
-- conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.80.1-hf8d6059_0.conda
-  sha256: 3d8f926d5db03762a1e3ff723295ea18674c29960e2e501a16c9413304698654
-  md5: 385a661cb1746cb6c62eb55712b412dd
+  size: 199771549
+  timestamp: 1726506487060
+- conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.81.0-hf8d6059_0.conda
+  sha256: 47b0f34453bc347739cb1b5eaaefe6a86aff2f4d91a333ecb56075714a188f3f
+  md5: 08ba4c469f11512a07583ace97766ee2
   depends:
-  - rust-std-x86_64-pc-windows-msvc 1.80.1 h17fc481_0
+  - rust-std-x86_64-pc-windows-msvc 1.81.0 h17fc481_0
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  size: 194534225
-  timestamp: 1723155969495
-- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.80.1-hf6ec828_0.conda
-  sha256: 6cd8c3cf93fb8348c815595eced946316bc81a0bf8c6fc8f6b9f27e270734770
-  md5: b3b07764d1fa59acf5c356bbb727db20
-  depends:
-  - __unix
-  constrains:
-  - rust >=1.80.1,<1.80.2.0a0
-  license: MIT
-  license_family: MIT
-  size: 30991019
-  timestamp: 1723152907303
-- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.80.1-h38e4360_0.conda
-  sha256: 56a30b275235975ea4e37f8d703818079601163aca92195a45468b0e7d6beffb
-  md5: b1ce3c6d57f2cf9f5a8b2448e3b6f499
+  size: 193252613
+  timestamp: 1726506914739
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.81.0-hf6ec828_0.conda
+  sha256: a8a31df1ef430f8dda4689f49e09e43dce333b02cfca39d61281652b950a69da
+  md5: 5f228231eb202cbd06b98e57697c470f
   depends:
   - __unix
   constrains:
-  - rust >=1.80.1,<1.80.2.0a0
+  - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
-  size: 31988631
-  timestamp: 1723152891461
-- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.80.1-h17fc481_0.conda
-  sha256: a4f118c6211f717846c094e58d3baef32215d1a2414d51c3e08b739dce75c28f
-  md5: f21862b6487af2fe504ca2b78dfec822
+  size: 31264180
+  timestamp: 1726503800830
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.81.0-h38e4360_0.conda
+  sha256: 18a2ceedf84a9b002e5bf68db3f9e5a4dd0fcb8c3d6c380004f094a3d0caae9d
+  md5: 37da4f96842452abf1b047a2b4b74893
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.81.0,<1.81.1.0a0
+  license: MIT
+  license_family: MIT
+  size: 32202262
+  timestamp: 1726503655773
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.81.0-h17fc481_0.conda
+  sha256: 2a7d0ac2035c09d31078602e194082e44a641ecfa5ca4edf47c16f25590b4fda
+  md5: 809e64792fbf0bd55fdf9e4577e46bae
   depends:
   - __win
   constrains:
-  - rust >=1.80.1,<1.80.2.0a0
+  - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
-  size: 25255952
-  timestamp: 1723155705619
-- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.80.1-h2c6d0dc_0.conda
-  sha256: 769cb83291804c9faa0de81534ceb3794cd06efd4d5164872bd5527e511f12a7
-  md5: 0a5b8783d18a253b0812a5501df297af
+  size: 25578327
+  timestamp: 1726506658685
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.81.0-h2c6d0dc_0.conda
+  sha256: 6539b9c5f787c9e579d4f0af763527fe890a0935357f99d5410e71fbbb165ee3
+  md5: e6d687c017e8af51a673081a2964ed1c
   depends:
   - __unix
   constrains:
-  - rust >=1.80.1,<1.80.2.0a0
+  - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
-  size: 33938994
-  timestamp: 1723153507938
+  size: 34828353
+  timestamp: 1726504171219
 - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
   sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
   md5: fc80f7995e396cbaeabd23cf46c413dc

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,33 +8,33 @@ platforms = ["osx-arm64", "win-64", "linux-64", "osx-64"]
 
 [tasks]
 run-release = { cmd = "cargo run --release", inputs = [
-    "crates/**",
-    "Cargo.toml",
-    "Cargo.lock",
+  "crates/**",
+  "Cargo.toml",
+  "Cargo.lock",
 ], outputs = [
-    "target/debug/**",
+  "target/debug/**",
 ] }
 
 build = { cmd = "cargo build", inputs = [
-    "crates/**",
-    "Cargo.toml",
-    "Cargo.lock",
+  "crates/**",
+  "Cargo.toml",
+  "Cargo.lock",
 ], outputs = [
-    "target/debug/**",
+  "target/debug/**",
 ] }
 build-release = { cmd = "cargo build --release", inputs = [
-    "crates/**",
-    "Cargo.toml",
-    "Cargo.lock",
+  "crates/**",
+  "Cargo.toml",
+  "Cargo.lock",
 ], outputs = [
-    "target/release/**",
+  "target/release/**",
 ] }
 run = { cmd = "cargo run", inputs = [
-    "crates/**",
-    "Cargo.toml",
-    "Cargo.lock",
+  "crates/**",
+  "Cargo.toml",
+  "Cargo.lock",
 ], outputs = [
-    "target/debug/**",
+  "target/debug/**",
 ] }
 
 
@@ -42,9 +42,9 @@ install-pixi-build-python = { cmd = "cargo install --path crates/pixi-build --bi
 install-pixi-build-cmake = { cmd = "cargo install --path crates/pixi-build --bin pixi-build-cmake --locked" }
 install-pixi-build-rattler-build = { cmd = "cargo install --path crates/pixi-build --bin pixi-build-rattler-build --locked" }
 install-pixi-backends = { depends-on = [
-    "install-pixi-build-python",
-    "install-pixi-build-cmake",
-    "install-pixi-build-rattler-build"
+  "install-pixi-build-python",
+  "install-pixi-build-cmake",
+  "install-pixi-build-rattler-build",
 ] }
 
 [dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,45 +8,47 @@ platforms = ["osx-arm64", "win-64", "linux-64", "osx-64"]
 
 [tasks]
 run-release = { cmd = "cargo run --release", inputs = [
-  "crates/**",
-  "Cargo.toml",
-  "Cargo.lock",
+    "crates/**",
+    "Cargo.toml",
+    "Cargo.lock",
 ], outputs = [
-  "target/debug/**",
+    "target/debug/**",
 ] }
 
 build = { cmd = "cargo build", inputs = [
-  "crates/**",
-  "Cargo.toml",
-  "Cargo.lock",
+    "crates/**",
+    "Cargo.toml",
+    "Cargo.lock",
 ], outputs = [
-  "target/debug/**",
+    "target/debug/**",
 ] }
 build-release = { cmd = "cargo build --release", inputs = [
-  "crates/**",
-  "Cargo.toml",
-  "Cargo.lock",
+    "crates/**",
+    "Cargo.toml",
+    "Cargo.lock",
 ], outputs = [
-  "target/release/**",
+    "target/release/**",
 ] }
 run = { cmd = "cargo run", inputs = [
-  "crates/**",
-  "Cargo.toml",
-  "Cargo.lock",
+    "crates/**",
+    "Cargo.toml",
+    "Cargo.lock",
 ], outputs = [
-  "target/debug/**",
+    "target/debug/**",
 ] }
 
 
 install-pixi-build-python = { cmd = "cargo install --path crates/pixi-build --bin pixi-build-python --locked" }
 install-pixi-build-cmake = { cmd = "cargo install --path crates/pixi-build --bin pixi-build-cmake --locked" }
+install-pixi-build-rattler-build = { cmd = "cargo install --path crates/pixi-build --bin pixi-build-rattler-build --locked" }
 install-pixi-backends = { depends-on = [
-  "install-pixi-build-python",
-  "install-pixi-build-cmake",
+    "install-pixi-build-python",
+    "install-pixi-build-cmake",
+    "install-pixi-build-rattler-build"
 ] }
 
 [dependencies]
-rust = "~=1.80.1"
+rust = "~=1.81.0"
 python = ">=3.12.4,<4"
 
 [feature.test.dependencies]


### PR DESCRIPTION
Remove reading the manifests from the backends and depends on the new project_model in pixi. Companion PR in pixi: https://github.com/prefix-dev/pixi/pull/2903

Some explanation why I've designed it in this way. I figured we could create a common type of functionality through traits and once these are defined, when there is a protocol update you only need to implement the traits for the updated protocol. Next, we can type the backends on these traits and select on basis of the project model version.

I'll add this functionality in a follow-up PR or when we actually require the change :)