### PR TITLE
feat: on release on tag

### DIFF
--- a/.github/workflows/rattler-build.yml
+++ b/.github/workflows/rattler-build.yml
@@ -1,7 +1,9 @@
 on:
   push:
-    branches:
-      - "main"
+    # Run full workflow on tags
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  # Run everything but publish on PRs
   pull_request:
 
 name: "Build Conda Package"


### PR DESCRIPTION
Only release when a tag is pushed.

The build should also run in a PR but the publish step will be skipped, because of the `event.push`.