### PR TITLE
fix: protocol method names

### DIFF
--- a/crates/pixi-build/src/bin/pixi-build-cmake/protocol.rs
+++ b/crates/pixi-build/src/bin/pixi-build-cmake/protocol.rs
@@ -55,7 +55,7 @@ impl CMakeBuildBackendInstantiator {
 }
 #[async_trait::async_trait]
 impl Protocol for CMakeBuildBackend {
-    async fn get_conda_metadata(
+    async fn conda_get_metadata(
         &self,
         params: CondaMetadataParams,
     ) -> miette::Result<CondaMetadataResult> {
@@ -192,7 +192,7 @@ impl Protocol for CMakeBuildBackend {
         })
     }
 
-    async fn build_conda(&self, params: CondaBuildParams) -> miette::Result<CondaBuildResult> {
+    async fn conda_build(&self, params: CondaBuildParams) -> miette::Result<CondaBuildResult> {
         let channel_config = ChannelConfig {
             channel_alias: params.channel_configuration.base_url,
             root_dir: self.manifest_root.to_path_buf(),

--- a/crates/pixi-build/src/bin/pixi-build-python/protocol.rs
+++ b/crates/pixi-build/src/bin/pixi-build-python/protocol.rs
@@ -35,7 +35,7 @@ use crate::{config::PythonBackendConfig, python::PythonBuildBackend};
 
 #[async_trait::async_trait]
 impl Protocol for PythonBuildBackend {
-    async fn get_conda_metadata(
+    async fn conda_get_metadata(
         &self,
         params: CondaMetadataParams,
     ) -> miette::Result<CondaMetadataResult> {
@@ -200,7 +200,7 @@ impl Protocol for PythonBuildBackend {
         })
     }
 
-    async fn build_conda(&self, params: CondaBuildParams) -> miette::Result<CondaBuildResult> {
+    async fn conda_build(&self, params: CondaBuildParams) -> miette::Result<CondaBuildResult> {
         let channel_config = ChannelConfig {
             channel_alias: params.channel_configuration.base_url,
             root_dir: self.manifest_root.to_path_buf(),

--- a/crates/pixi-build/src/bin/pixi-build-rattler-build/protocol.rs
+++ b/crates/pixi-build/src/bin/pixi-build-rattler-build/protocol.rs
@@ -47,7 +47,7 @@ impl RattlerBuildBackendInstantiator {
 
 #[async_trait::async_trait]
 impl Protocol for RattlerBuildBackend {
-    async fn get_conda_metadata(
+    async fn conda_get_metadata(
         &self,
         params: CondaMetadataParams,
     ) -> miette::Result<CondaMetadataResult> {
@@ -188,7 +188,7 @@ impl Protocol for RattlerBuildBackend {
         })
     }
 
-    async fn build_conda(&self, params: CondaBuildParams) -> miette::Result<CondaBuildResult> {
+    async fn conda_build(&self, params: CondaBuildParams) -> miette::Result<CondaBuildResult> {
         // Create the work directory if it does not exist
         fs::create_dir_all(&params.work_directory).into_diagnostic()?;
 
@@ -359,7 +359,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_get_conda_metadata() {
+    async fn test_conda_get_metadata() {
         // get cargo manifest dir
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let recipe = manifest_dir.join("../../recipe/recipe.yaml");
@@ -378,7 +378,7 @@ mod tests {
 
         let result = factory
             .0
-            .get_conda_metadata(CondaMetadataParams {
+            .conda_get_metadata(CondaMetadataParams {
                 host_platform: None,
                 build_platform: None,
                 channel_configuration: ChannelConfiguration {
@@ -414,7 +414,7 @@ mod tests {
 
         let result = factory
             .0
-            .build_conda(CondaBuildParams {
+            .conda_build(CondaBuildParams {
                 build_platform_virtual_packages: None,
                 host_platform: None,
                 channel_base_urls: None,

--- a/crates/pixi-build/src/cli.rs
+++ b/crates/pixi-build/src/cli.rs
@@ -116,7 +116,7 @@ pub async fn main<T: ProtocolInstantiator, F: FnOnce(LoggingOutputHandler) -> T>
             manifest_path,
             host_platform,
         }) => {
-            let metadata = get_conda_metadata(factory, &manifest_path, host_platform).await?;
+            let metadata = conda_get_metadata(factory, &manifest_path, host_platform).await?;
             println!("{}", serde_yaml::to_string(&metadata).unwrap());
             Ok(())
         }
@@ -175,7 +175,7 @@ async fn initialize<T: ProtocolInstantiator>(
 }
 
 /// Frontend implementation for getting conda metadata.
-async fn get_conda_metadata<T: ProtocolInstantiator>(
+async fn conda_get_metadata<T: ProtocolInstantiator>(
     factory: T,
     manifest_path: &Path,
     host_platform: Option<Platform>,
@@ -199,7 +199,7 @@ async fn get_conda_metadata<T: ProtocolInstantiator>(
         .context("failed to create a temporary directory in the current directory")?;
 
     protocol
-        .get_conda_metadata(CondaMetadataParams {
+        .conda_get_metadata(CondaMetadataParams {
             build_platform: None,
             host_platform: host_platform.map(|platform| PlatformAndVirtualPackages {
                 platform,
@@ -240,7 +240,7 @@ async fn build<T: ProtocolInstantiator>(factory: T, manifest_path: &Path) -> mie
         .context("failed to create a temporary directory in the current directory")?;
 
     let result = protocol
-        .build_conda(CondaBuildParams {
+        .conda_build(CondaBuildParams {
             host_platform: None,
             build_platform_virtual_packages: None,
             channel_base_urls: None,

--- a/crates/pixi-build/src/protocol.rs
+++ b/crates/pixi-build/src/protocol.rs
@@ -32,15 +32,15 @@ pub trait ProtocolInstantiator: Send + Sync + 'static {
 #[async_trait::async_trait]
 pub trait Protocol {
     /// Called when the client requests metadata for a Conda package.
-    async fn get_conda_metadata(
+    async fn conda_get_metadata(
         &self,
         _params: CondaMetadataParams,
     ) -> miette::Result<CondaMetadataResult> {
-        unimplemented!("get_conda_metadata not implemented");
+        unimplemented!("conda_get_metadata not implemented");
     }
 
     /// Called when the client requests to build a Conda package.
-    async fn build_conda(&self, _params: CondaBuildParams) -> miette::Result<CondaBuildResult> {
-        unimplemented!("build_conda not implemented");
+    async fn conda_build(&self, _params: CondaBuildParams) -> miette::Result<CondaBuildResult> {
+        unimplemented!("conda_build not implemented");
     }
 }

--- a/crates/pixi-build/src/server.rs
+++ b/crates/pixi-build/src/server.rs
@@ -105,7 +105,7 @@ impl<T: ProtocolInstantiator> Server<T> {
                     let state = state.read().await;
                     state
                         .as_endpoint()?
-                        .get_conda_metadata(params)
+                        .conda_get_metadata(params)
                         .await
                         .map(|value| to_value(value).expect("failed to convert to json"))
                         .map_err(convert_error)
@@ -124,7 +124,7 @@ impl<T: ProtocolInstantiator> Server<T> {
                     let state = state.read().await;
                     state
                         .as_endpoint()?
-                        .build_conda(params)
+                        .conda_build(params)
                         .await
                         .map(|value| to_value(value).expect("failed to convert to json"))
                         .map_err(convert_error)


### PR DESCRIPTION
That way they fit with the RPC method names `conda/getMetadata` and `conda/build`