### PR TITLE
fix: use input globs

### DIFF
--- a/crates/pixi-build/src/bin/pixi-build-python/protocol.rs
+++ b/crates/pixi-build/src/bin/pixi-build-python/protocol.rs
@@ -196,7 +196,7 @@ impl Protocol for PythonBuildBackend {
 
         Ok(CondaMetadataResult {
             packages,
-            input_globs: None,
+            input_globs: Some(input_globs()),
         })
     }
 


### PR DESCRIPTION
@tdejager I think you touched this code last - was there a reason to not return the input globs here?