### PR TITLE
fix: export openssl

### DIFF
--- a/crates/pixi-build-backend/src/traits/targets.rs
+++ b/crates/pixi-build-backend/src/traits/targets.rs
@@ -54,6 +54,11 @@ impl<'a, S> Dependencies<'a, S> {
             build: IndexMap::new(),
         }
     }
+
+    /// Return true if the dependencies contains the given package name
+    pub fn contains(&self, name: &SourcePackageName) -> bool {
+        self.run.contains_key(name) || self.host.contains_key(name) || self.build.contains_key(name)
+    }
 }
 
 /// A trait that represent a project target.

--- a/crates/pixi-build-rust/src/build_script.j2
+++ b/crates/pixi-build-rust/src/build_script.j2
@@ -1,2 +1,5 @@
+{% if export_openssl -%}
 export OPENSSL_DIR="$PREFIX"
-cargo install --locked --root $PREFIX --path {{ source_dir }} --no-track {{ extra_args | join(" ") }}
+{% endif %}
+
+cargo install --locked --root $PREFIX --path {{ source_dir }} --no-track {{ extra_args | join(" ") }} --force

--- a/crates/pixi-build-rust/src/build_script.rs
+++ b/crates/pixi-build-rust/src/build_script.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 pub struct BuildScriptContext {
     pub source_dir: String,
     pub extra_args: Vec<String>,
+    pub export_openssl: bool,
 }
 
 impl BuildScriptContext {

--- a/crates/pixi-build-rust/src/rust.rs
+++ b/crates/pixi-build-rust/src/rust.rs
@@ -93,11 +93,17 @@ impl<P: ProjectModel> RustBuildBackend<P> {
 
         let requirements = self.requirements(host_platform, channel_config, variant)?;
 
+        let export_openssl = self
+            .project_model
+            .dependencies(Some(host_platform))
+            .contains(&"openssl".into());
+
         let build_number = 0;
 
         let build_script = BuildScriptContext {
             source_dir: self.manifest_root.display().to_string(),
             extra_args: self.config.extra_args.clone(),
+            export_openssl,
         }
         .render();
 


### PR DESCRIPTION
unblock: https://github.com/prefix-dev/pixi-build-backends/pull/98

## Overview

Sometimes when building a rust-based conda package, you may need or not openssl in host dependencies in order to build it.

This PR only `optionally` export `OPENSSL_DIR` if OpenSSL is present in any dependencies


