### PR TITLE
fix: use correct build and host platform

### DIFF
--- a/crates/pixi-build-cmake/src/protocol.rs
+++ b/crates/pixi-build-cmake/src/protocol.rs
@@ -250,10 +250,13 @@ impl Protocol for CMakeBuildBackend<ProjectModelV1> {
 
             let build_configuration_params = build_configuration(
                 channels.clone(),
-                params.host_platform.clone(),
+                Some(PlatformAndVirtualPackages {
+                    platform: Platform::current(),
+                    virtual_packages: params.build_platform_virtual_packages.clone(),
+                }),
                 Some(PlatformAndVirtualPackages {
                     platform: host_platform,
-                    virtual_packages: params.build_platform_virtual_packages.clone(),
+                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
                 }),
                 variant.clone(),
                 directories.clone(),

--- a/crates/pixi-build-cmake/src/protocol.rs
+++ b/crates/pixi-build-cmake/src/protocol.rs
@@ -256,7 +256,10 @@ impl Protocol for CMakeBuildBackend<ProjectModelV1> {
                 }),
                 Some(PlatformAndVirtualPackages {
                     platform: host_platform,
-                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
+                    virtual_packages: params
+                        .host_platform
+                        .clone()
+                        .and_then(|p| p.virtual_packages),
                 }),
                 variant.clone(),
                 directories.clone(),

--- a/crates/pixi-build-python/src/protocol.rs
+++ b/crates/pixi-build-python/src/protocol.rs
@@ -114,8 +114,14 @@ impl<P: ProjectModel + Sync> Protocol for PythonBuildBackend<P> {
             let recipe = self.recipe(host_platform, &channel_config, false, &variant)?;
             let build_configuration_params = build_configuration(
                 channels.clone(),
-                params.build_platform.clone(),
-                params.host_platform.clone(),
+                Some(PlatformAndVirtualPackages {
+                    platform: params.build_platform.clone().map(|p| p.platform).unwrap_or(Platform::current()),
+                    virtual_packages: params.build_platform.clone().and_then(|p| p.virtual_packages),
+                }),
+                Some(PlatformAndVirtualPackages {
+                    platform: host_platform,
+                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
+                }),
                 variant.clone(),
                 directories.clone(),
             )?;
@@ -241,10 +247,13 @@ impl<P: ProjectModel + Sync> Protocol for PythonBuildBackend<P> {
             let recipe = self.recipe(host_platform, &channel_config, params.editable, &variant)?;
             let build_configuration_params = build_configuration(
                 channels.clone(),
-                params.host_platform.clone(),
+                Some(PlatformAndVirtualPackages {
+                    platform: Platform::current(),
+                    virtual_packages: params.build_platform_virtual_packages.clone(),
+                }),
                 Some(PlatformAndVirtualPackages {
                     platform: host_platform,
-                    virtual_packages: params.build_platform_virtual_packages.clone(),
+                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
                 }),
                 variant.clone(),
                 directories.clone(),

--- a/crates/pixi-build-python/src/protocol.rs
+++ b/crates/pixi-build-python/src/protocol.rs
@@ -114,24 +114,8 @@ impl<P: ProjectModel + Sync> Protocol for PythonBuildBackend<P> {
             let recipe = self.recipe(host_platform, &channel_config, false, &variant)?;
             let build_configuration_params = build_configuration(
                 channels.clone(),
-                Some(PlatformAndVirtualPackages {
-                    platform: params
-                        .build_platform
-                        .clone()
-                        .map(|p| p.platform)
-                        .unwrap_or(Platform::current()),
-                    virtual_packages: params
-                        .build_platform
-                        .clone()
-                        .and_then(|p| p.virtual_packages),
-                }),
-                Some(PlatformAndVirtualPackages {
-                    platform: host_platform,
-                    virtual_packages: params
-                        .host_platform
-                        .clone()
-                        .and_then(|p| p.virtual_packages),
-                }),
+                params.build_platform.clone(),
+                params.host_platform.clone(),
                 variant.clone(),
                 directories.clone(),
             )?;

--- a/crates/pixi-build-python/src/protocol.rs
+++ b/crates/pixi-build-python/src/protocol.rs
@@ -115,12 +115,22 @@ impl<P: ProjectModel + Sync> Protocol for PythonBuildBackend<P> {
             let build_configuration_params = build_configuration(
                 channels.clone(),
                 Some(PlatformAndVirtualPackages {
-                    platform: params.build_platform.clone().map(|p| p.platform).unwrap_or(Platform::current()),
-                    virtual_packages: params.build_platform.clone().and_then(|p| p.virtual_packages),
+                    platform: params
+                        .build_platform
+                        .clone()
+                        .map(|p| p.platform)
+                        .unwrap_or(Platform::current()),
+                    virtual_packages: params
+                        .build_platform
+                        .clone()
+                        .and_then(|p| p.virtual_packages),
                 }),
                 Some(PlatformAndVirtualPackages {
                     platform: host_platform,
-                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
+                    virtual_packages: params
+                        .host_platform
+                        .clone()
+                        .and_then(|p| p.virtual_packages),
                 }),
                 variant.clone(),
                 directories.clone(),
@@ -253,7 +263,10 @@ impl<P: ProjectModel + Sync> Protocol for PythonBuildBackend<P> {
                 }),
                 Some(PlatformAndVirtualPackages {
                     platform: host_platform,
-                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
+                    virtual_packages: params
+                        .host_platform
+                        .clone()
+                        .and_then(|p| p.virtual_packages),
                 }),
                 variant.clone(),
                 directories.clone(),

--- a/crates/pixi-build-rust/src/protocol.rs
+++ b/crates/pixi-build-rust/src/protocol.rs
@@ -114,8 +114,14 @@ impl<P: ProjectModel + Sync> Protocol for RustBuildBackend<P> {
             let recipe = self.recipe(host_platform, &channel_config, &variant)?;
             let build_configuration_params = build_configuration(
                 channels.clone(),
-                params.build_platform.clone(),
-                params.host_platform.clone(),
+                Some(PlatformAndVirtualPackages {
+                    platform: params.build_platform.clone().map(|p| p.platform).unwrap_or(Platform::current()),
+                    virtual_packages: params.build_platform.clone().and_then(|p| p.virtual_packages),
+                }),
+                Some(PlatformAndVirtualPackages {
+                    platform: host_platform,
+                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
+                }),
                 variant.clone(),
                 directories.clone(),
             )?;
@@ -241,10 +247,13 @@ impl<P: ProjectModel + Sync> Protocol for RustBuildBackend<P> {
             let recipe = self.recipe(host_platform, &channel_config, &variant)?;
             let build_configuration_params = build_configuration(
                 channels.clone(),
-                params.host_platform.clone(),
+                Some(PlatformAndVirtualPackages {
+                    platform: Platform::current(),
+                    virtual_packages: params.build_platform_virtual_packages.clone(),
+                }),
                 Some(PlatformAndVirtualPackages {
                     platform: host_platform,
-                    virtual_packages: params.build_platform_virtual_packages.clone(),
+                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
                 }),
                 variant.clone(),
                 directories.clone(),

--- a/crates/pixi-build-rust/src/protocol.rs
+++ b/crates/pixi-build-rust/src/protocol.rs
@@ -115,12 +115,22 @@ impl<P: ProjectModel + Sync> Protocol for RustBuildBackend<P> {
             let build_configuration_params = build_configuration(
                 channels.clone(),
                 Some(PlatformAndVirtualPackages {
-                    platform: params.build_platform.clone().map(|p| p.platform).unwrap_or(Platform::current()),
-                    virtual_packages: params.build_platform.clone().and_then(|p| p.virtual_packages),
+                    platform: params
+                        .build_platform
+                        .clone()
+                        .map(|p| p.platform)
+                        .unwrap_or(Platform::current()),
+                    virtual_packages: params
+                        .build_platform
+                        .clone()
+                        .and_then(|p| p.virtual_packages),
                 }),
                 Some(PlatformAndVirtualPackages {
                     platform: host_platform,
-                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
+                    virtual_packages: params
+                        .host_platform
+                        .clone()
+                        .and_then(|p| p.virtual_packages),
                 }),
                 variant.clone(),
                 directories.clone(),
@@ -253,7 +263,10 @@ impl<P: ProjectModel + Sync> Protocol for RustBuildBackend<P> {
                 }),
                 Some(PlatformAndVirtualPackages {
                     platform: host_platform,
-                    virtual_packages: params.host_platform.clone().and_then(|p| p.virtual_packages),
+                    virtual_packages: params
+                        .host_platform
+                        .clone()
+                        .and_then(|p| p.virtual_packages),
                 }),
                 variant.clone(),
                 directories.clone(),

--- a/crates/pixi-build-rust/src/protocol.rs
+++ b/crates/pixi-build-rust/src/protocol.rs
@@ -114,24 +114,8 @@ impl<P: ProjectModel + Sync> Protocol for RustBuildBackend<P> {
             let recipe = self.recipe(host_platform, &channel_config, &variant)?;
             let build_configuration_params = build_configuration(
                 channels.clone(),
-                Some(PlatformAndVirtualPackages {
-                    platform: params
-                        .build_platform
-                        .clone()
-                        .map(|p| p.platform)
-                        .unwrap_or(Platform::current()),
-                    virtual_packages: params
-                        .build_platform
-                        .clone()
-                        .and_then(|p| p.virtual_packages),
-                }),
-                Some(PlatformAndVirtualPackages {
-                    platform: host_platform,
-                    virtual_packages: params
-                        .host_platform
-                        .clone()
-                        .and_then(|p| p.virtual_packages),
-                }),
+                params.build_platform.clone(),
+                params.host_platform.clone(),
                 variant.clone(),
                 directories.clone(),
             )?;


### PR DESCRIPTION
Preparation for https://github.com/prefix-dev/pixi-build-backends/pull/98

The reason to split up these changes - I want to make a proper release of backends.