### PR TITLE
release: bump pixi-build-rust 0.1.5 and pixi-build-cmake 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-cmake"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-rust"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/pixi-build-cmake/Cargo.toml
+++ b/crates/pixi-build-cmake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi-build-cmake"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 
 [dependencies]

--- a/crates/pixi-build-rust/Cargo.toml
+++ b/crates/pixi-build-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi-build-rust"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
bump both crates