### PR TITLE
fix: check if `build.ninja` exists to reconfigure cmake

### DIFF
--- a/crates/pixi-build-cmake/src/build_script.j2
+++ b/crates/pixi-build-cmake/src/build_script.j2
@@ -3,7 +3,7 @@ cmake --version
 
 {# Windows #}
 {% if build_platform == "windows" -%}
-if not exist %SRC_DIR%\..\build\CMakeCache.txt (
+if not exist %SRC_DIR%\..\build\build.ninja (
     cmake %CMAKE_ARGS% ^
           -GNinja ^
           -DCMAKE_BUILD_TYPE=Release ^
@@ -20,7 +20,7 @@ cmake --build %SRC_DIR%\..\build --target install
 
 {# Non Windows #}
 {% else -%}
-if [ ! -f "$SRC_DIR/../build/CMakeCache.txt" ]; then
+if [ ! -f "$SRC_DIR/../build/build.ninja" ]; then
     cmake $CMAKE_ARGS \
           -GNinja \
           -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Fixes https://github.com/prefix-dev/pixi/issues/3436

The cmake build backend checked if a `CMakeCache.txt` file exists to determine if CMake needed to be rerun to reconfigure the project. However, if the first configure step failed  the `CMakeCache.txt` was still created even though on a subsequent run `cmake` should be rerun. 

We could just not have the check and run `cmake` on every invocation, but that adds significant overhead. Instead, we can check if the `build.ninja` file exists. After that, we can always invoke `cmake --build` because if any cmake file changed ninja itself will reconfigure the project.