### PR TITLE
feat: glob recipe.yaml parent directory more properly

### DIFF
--- a/crates/pixi-build-python/src/protocol.rs
+++ b/crates/pixi-build-python/src/protocol.rs
@@ -349,7 +349,7 @@ impl<P: ProjectModel + Sync> Protocol for PythonBuildBackend<P> {
                 .await?;
             let built_package = CondaBuiltPackage {
                 output_file: package,
-                input_globs: input_globs(),
+                input_globs: input_globs(params.editable),
                 name: output.name().as_normalized().to_string(),
                 version: output.version().to_string(),
                 build: build_string.to_string(),
@@ -367,13 +367,12 @@ impl<P: ProjectModel + Sync> Protocol for PythonBuildBackend<P> {
 /// has a different way of determining the input globs than hatch etc.
 ///
 /// However, lets take everything in the directory as input for now
-fn input_globs() -> Vec<String> {
-    vec![
+fn input_globs(editable: bool) -> Vec<String> {
+    let mut globs = vec![
         // Source files
-        "**/*.py",
-        "**/*.pyx",
         "**/*.c",
         "**/*.cpp",
+        "**/*.rs",
         "**/*.sh",
         // Common data files
         "**/*.json",
@@ -401,7 +400,12 @@ fn input_globs() -> Vec<String> {
     ]
     .iter()
     .map(|s| s.to_string())
-    .collect()
+    .collect();
+
+    if !editable {
+        globs.push("**/*.py".to_string());
+        globs.push("**/*.pyx".to_string());
+    }
 }
 
 pub struct PythonBuildBackendInstantiator {

--- a/crates/pixi-build-python/src/protocol.rs
+++ b/crates/pixi-build-python/src/protocol.rs
@@ -368,7 +368,7 @@ impl<P: ProjectModel + Sync> Protocol for PythonBuildBackend<P> {
 ///
 /// However, lets take everything in the directory as input for now
 fn input_globs(editable: bool) -> Vec<String> {
-    let mut globs = vec![
+    let mut globs: Vec<_> = vec![
         // Source files
         "**/*.c",
         "**/*.cpp",
@@ -406,6 +406,8 @@ fn input_globs(editable: bool) -> Vec<String> {
         globs.push("**/*.py".to_string());
         globs.push("**/*.pyx".to_string());
     }
+
+    globs
 }
 
 pub struct PythonBuildBackendInstantiator {

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -344,7 +344,11 @@ fn input_globs(
         for source in package_sources {
             if let rattler_build::recipe::parser::Source::Path(path_source) = source {
                 // add the package source path as glob
-                input_globs.push(format!("{}/**", path_source.path.display()));
+                if path_source.path.is_dir() {
+                    input_globs.push(format!("{}/**", path_source.path.display()));
+                } else {
+                    input_globs.push(path_source.path.display().to_string());
+                }
             }
         }
     }

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -5,6 +5,7 @@ use fs_err::tokio as tokio_fs;
 use miette::{Context, IntoDiagnostic};
 use pixi_build_backend::{
     protocol::{Protocol, ProtocolInstantiator},
+    source::Source,
     tools::RattlerBuild,
     utils::TemporaryRenderedRecipe,
 };
@@ -131,8 +132,6 @@ impl Protocol for RattlerBuildBackend {
 
         let mut solved_packages = vec![];
 
-        eprintln!("before outputs ");
-
         for output in outputs {
             let temp_recipe = TemporaryRenderedRecipe::from_output(&output)?;
             let tool_config = &tool_config;
@@ -190,7 +189,7 @@ impl Protocol for RattlerBuildBackend {
 
         Ok(CondaMetadataResult {
             packages: solved_packages,
-            input_globs: None,
+            input_globs: Some(input_globs(&self.recipe_source)),
         })
     }
 
@@ -310,7 +309,7 @@ impl Protocol for RattlerBuildBackend {
 
             built.push(CondaBuiltPackage {
                 output_file: build_path,
-                input_globs: Vec::from([self.recipe_source.name.clone()]),
+                input_globs: input_globs(&self.recipe_source),
                 name: output.name().as_normalized().to_string(),
                 version: output.version().to_string(),
                 build: build_string.to_string(),
@@ -319,6 +318,21 @@ impl Protocol for RattlerBuildBackend {
         }
         Ok(CondaBuildResult { packages: built })
     }
+}
+
+fn input_globs(source: &Source) -> Vec<String> {
+    let mut input_globs = vec![];
+    if source.path.is_file() {
+        // use the parent path as glob
+        if let Some(parent) = source.path.parent() {
+            input_globs.push(format!("{}/**", parent.display()));
+        }
+    } else {
+        // use the source path as glob
+        input_globs.push(format!("{}/**", source.path.display()));
+    }
+
+    input_globs
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
Also adds input globs for metadata which I think should help with caching? 

We glob the whole folder because it is possible that e.g. `build.sh` or a patch changes. 

Ideally we would probably also glob the `source` folder ... 
Or even more ideally we would have methods to find _all_ referenced (local) files from a `recipe.yaml` and add them all to the input hash.