### PR TITLE
fix: resolve build string

### DIFF
--- a/crates/pixi-build-backend/src/tools.rs
+++ b/crates/pixi-build-backend/src/tools.rs
@@ -8,7 +8,6 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
 use pixi_build_types::procedures::conda_metadata::CondaMetadataParams;
-use rattler_build::metadata::Debug;
 use rattler_build::{
     hash::HashInfo,
     metadata::{
@@ -24,6 +23,7 @@ use rattler_build::{
     system_tools::SystemTools,
     variant_config::{DiscoveredOutput, ParseErrors, VariantConfig},
 };
+use rattler_build::{metadata::Debug, recipe::parser::BuildString};
 use rattler_conda_types::{GenericVirtualPackage, Platform, package::ArchiveType};
 use rattler_package_streaming::write::CompressionLevel;
 use rattler_virtual_packages::VirtualPackageOverrides;
@@ -165,6 +165,11 @@ impl RattlerBuild {
                         .into();
                     errs
                 })?;
+
+            recipe.build.string = BuildString::Resolved(BuildString::compute(
+                &discovered_output.hash,
+                recipe.build.number,
+            ));
 
             for source in &mut recipe.source {
                 if let rattler_build::recipe::parser::Source::Path(path_source) = source {


### PR DESCRIPTION
I noticed that with https://github.com/prefix-dev/pixi-build-backends/pull/125 some of the Pixi tests started failing.

With the help of Bas, I found that the reason was a debug log that required a resolved build string at that point.
