### PR TITLE
chore: update pixi.toml

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ Pull requests will build the packages but not publish them
 ## Usage Instructions
 
 ### Triggering a Release
-- Bump the version in the `Cargo.toml` for the backend you want to release.
+- Bump the version in the `Cargo.toml` and corresponding `pixi.toml` for the backend you want to release.
 - Open a pull request
 - After the pull request is merged, create a new tag following the pattern `pixi-build-<backend>-vX.Y.Z` (e.g., `pixi-build-cmake-v1.2.3`)
 - Push the tag to the repository:

--- a/crates/pixi-build-cmake/pixi.toml
+++ b/crates/pixi-build-cmake/pixi.toml
@@ -10,7 +10,7 @@ preview = ["pixi-build"]
 authors = ["Nichita Morcotilo <nichita@prefix.dev>"]
 description = "Showcases how to build a cpp project with pixi"
 name = "pixi-build-cmake"
-version = "0.1.5"
+version = "0.1.6"
 
 
 [dependencies]

--- a/crates/pixi-build-python/pixi.toml
+++ b/crates/pixi-build-python/pixi.toml
@@ -10,7 +10,7 @@ preview = ["pixi-build"]
 authors = ["Nichita Morcotilo <nichita@prefix.dev>"]
 description = "Showcases how to build a python project with pixi"
 name = "pixi-build-python"
-version = "0.1.5"
+version = "0.1.6"
 
 
 [dependencies]

--- a/crates/pixi-build-rattler-build/pixi.toml
+++ b/crates/pixi-build-rattler-build/pixi.toml
@@ -10,7 +10,7 @@ preview = ["pixi-build"]
 authors = ["Nichita Morcotilo <nichita@prefix.dev>"]
 description = "Showcases how to build a rattler-build recipe with pixi"
 name = "pixi-build-rattler-build"
-version = "0.1.4"
+version = "0.1.5"
 
 
 [dependencies]

--- a/crates/pixi-build-rust/pixi.toml
+++ b/crates/pixi-build-rust/pixi.toml
@@ -10,7 +10,7 @@ preview = ["pixi-build"]
 authors = ["Nichita Morcotilo <nichita@prefix.dev>"]
 description = "Showcases how to build a rust project with pixi"
 name = "pixi-build-rust"
-version = "0.1.6"
+version = "0.1.7"
 
 
 [dependencies]


### PR DESCRIPTION
Our release docs wasn't up-to-date unfortunately.
We should automate this more in general.
At the moment, releasing all crates takes effort and is error prone