### PR TITLE
fix: rattler-build backend globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3966,6 +3966,7 @@ dependencies = [
  "async-trait",
  "fs-err",
  "miette",
+ "pathdiff",
  "pixi-build-backend",
  "pixi_build_types",
  "rattler-build",

--- a/crates/pixi-build-rattler-build/Cargo.toml
+++ b/crates/pixi-build-rattler-build/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 url = { workspace = true }
+pathdiff = { workspace = true }
 
 pixi-build-backend = { workspace = true }
 


### PR DESCRIPTION
The current system has two problems:
- they contain absolute paths which will not error on unix, but also not do what we want
- they contain `\` on Windows, which wax will not accept at all

The correct behavior should be to get the relative path to the source directory and then join the components with "/"