### PR TITLE
fix: relative source paths `pixi-build-rattler-build`

### DIFF
--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -345,11 +345,9 @@ impl Protocol for RattlerBuildBackend {
     }
 }
 
+#[allow(dead_code)]
 /// Returns the relative path from `base` to `input`, joined by "/".
-pub fn relative_path_joined(
-    base: &std::path::Path,
-    input: &std::path::Path,
-) -> miette::Result<String> {
+fn relative_path_joined(base: &std::path::Path, input: &std::path::Path) -> miette::Result<String> {
     let rel = pathdiff::diff_paths(input, base).ok_or_else(|| {
         miette::miette!(
             "could not compute relative path from '{:?}' to '{:?}'",
@@ -366,32 +364,32 @@ pub fn relative_path_joined(
 }
 
 fn build_input_globs(
-    source: &Path,
-    package_sources: Option<Vec<PathBuf>>,
+    _source: &Path,
+    _package_sources: Option<Vec<PathBuf>>,
 ) -> miette::Result<Vec<String>> {
     // Always add the current directory of the package to the globs
-    let mut input_globs = vec!["*/**".to_string()];
+    let input_globs = vec!["*/**".to_string()];
 
-    // Get parent directory path
-    let parent = if source.is_file() {
-        // use the parent path as glob
-        source.parent().unwrap_or(source).to_path_buf()
-    } else {
-        // use the source path as glob
-        source.to_path_buf()
-    };
-
-    // If there are sources add them to the globs as well
-    if let Some(package_sources) = package_sources {
-        for source in package_sources {
-            let source_glob = relative_path_joined(&parent, &source)?;
-            if source.is_dir() {
-                input_globs.push(format!("{}/**", source_glob));
-            } else {
-                input_globs.push(source_glob);
-            }
-        }
-    }
+    // Enable together with https://github.com/prefix-dev/pixi/issues/3785
+    // // Get parent directory path
+    // let parent = if source.is_file() {
+    //     // use the parent path as glob
+    //     source.parent().unwrap_or(source).to_path_buf()
+    // } else {
+    //     // use the source path as glob
+    //     source.to_path_buf()
+    // };
+    // // If there are sources add them to the globs as well
+    // if let Some(package_sources) = package_sources {
+    //     for source in package_sources {
+    //         let source_glob = relative_path_joined(&parent, &source)?;
+    //         if source.is_dir() {
+    //             input_globs.push(format!("{}/**", source_glob));
+    //         } else {
+    //             input_globs.push(source_glob);
+    //         }
+    //     }
+    // }
 
     Ok(input_globs)
 }

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -364,32 +364,36 @@ fn relative_path_joined(base: &std::path::Path, input: &std::path::Path) -> miet
 }
 
 fn build_input_globs(
-    _source: &Path,
-    _package_sources: Option<Vec<PathBuf>>,
+    source: &Path,
+    package_sources: Option<Vec<PathBuf>>,
 ) -> miette::Result<Vec<String>> {
     // Always add the current directory of the package to the globs
-    let input_globs = vec!["*/**".to_string()];
+    let mut input_globs = vec!["*/**".to_string()];
 
-    // Enable together with https://github.com/prefix-dev/pixi/issues/3785
-    // // Get parent directory path
-    // let parent = if source.is_file() {
-    //     // use the parent path as glob
-    //     source.parent().unwrap_or(source).to_path_buf()
-    // } else {
-    //     // use the source path as glob
-    //     source.to_path_buf()
-    // };
-    // // If there are sources add them to the globs as well
-    // if let Some(package_sources) = package_sources {
-    //     for source in package_sources {
-    //         let source_glob = relative_path_joined(&parent, &source)?;
-    //         if source.is_dir() {
-    //             input_globs.push(format!("{}/**", source_glob));
-    //         } else {
-    //             input_globs.push(source_glob);
-    //         }
-    //     }
-    // }
+    // TODO: Remove this condition when working on https://github.com/prefix-dev/pixi/issues/3785
+    if !source.is_absolute() {
+        return Ok(input_globs);
+    }
+
+    // Get parent directory path
+    let parent = if source.is_file() {
+        // use the parent path as glob
+        source.parent().unwrap_or(source).to_path_buf()
+    } else {
+        // use the source path as glob
+        source.to_path_buf()
+    };
+    // If there are sources add them to the globs as well
+    if let Some(package_sources) = package_sources {
+        for source in package_sources {
+            let source_glob = relative_path_joined(&parent, &source)?;
+            if source.is_dir() {
+                input_globs.push(format!("{}/**", source_glob));
+            } else {
+                input_globs.push(source_glob);
+            }
+        }
+    }
 
     Ok(input_globs)
 }


### PR DESCRIPTION
Let's remove this code path for now until we need it for https://github.com/prefix-dev/pixi/issues/3778.

Then we should make sure to pass absolute paths, since `pathdiff` cannot compare absolute paths with relative ones.