### PR TITLE
fix: use default linker on osx-64

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -53,6 +53,9 @@ install-pixi-backends = { depends-on = [
 rust = ">=1.86.0,<1.87"
 python = ">=3.12.4,<4"
 
+[target.osx-64.activation]
+scripts = ["scripts/default_linker_osx_64.sh"]
+
 [feature.test.dependencies]
 pytest = ">=8.3.2,<9"
 

--- a/scripts/default_linker_osx_64.sh
+++ b/scripts/default_linker_osx_64.sh
@@ -1,0 +1,3 @@
+# Ignore requiring a shebang as this is a script meant to be sourced
+# shellcheck disable=SC2148
+unset CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER


### PR DESCRIPTION
This should unblock osx-64 releases.
See also https://github.com/rust-lang/rust/issues/140686