### PR TITLE
Return source records with pixi-build-rattler-build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,6 +3895,7 @@ version = "0.1.14"
 dependencies = [
  "async-trait",
  "fs-err",
+ "itertools 0.14.0",
  "miette",
  "pathdiff",
  "pixi-build-backend",

--- a/crates/pixi-build-rattler-build/Cargo.toml
+++ b/crates/pixi-build-rattler-build/Cargo.toml
@@ -16,7 +16,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 url = { workspace = true }
 pathdiff = { workspace = true }
-itertools = {workspace = true}
+itertools = { workspace = true }
 
 pixi-build-backend = { workspace = true }
 

--- a/crates/pixi-build-rattler-build/Cargo.toml
+++ b/crates/pixi-build-rattler-build/Cargo.toml
@@ -16,6 +16,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 url = { workspace = true }
 pathdiff = { workspace = true }
+itertools = {workspace = true}
 
 pixi-build-backend = { workspace = true }
 

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use std::collections::HashMap;
 use std::{
     path::{Path, PathBuf},
@@ -13,20 +14,20 @@ use pixi_build_backend::{
 };
 use pixi_build_types::procedures::conda_build::CondaOutputIdentifier;
 use pixi_build_types::{
+    BackendCapabilities, CondaPackageMetadata,
     procedures::{
         conda_build::{CondaBuildParams, CondaBuildResult, CondaBuiltPackage},
         conda_metadata::{CondaMetadataParams, CondaMetadataResult},
         initialize::{InitializeParams, InitializeResult},
         negotiate_capabilities::{NegotiateCapabilitiesParams, NegotiateCapabilitiesResult},
     },
-    BackendCapabilities, CondaPackageMetadata,
 };
 use rattler_build::{
     build::run_build,
     console_utils::LoggingOutputHandler,
     hash::HashInfo,
     metadata::PlatformWithVirtualPackages,
-    recipe::{parser::BuildString, Jinja},
+    recipe::{Jinja, parser::BuildString},
     render::resolved_dependencies::DependencyInfo,
     selectors::SelectorConfig,
     tool_configuration::{BaseClient, Configuration},
@@ -141,12 +142,13 @@ impl Protocol for RattlerBuildBackend {
 
         let mut solved_packages = vec![];
 
-        for output in outputs {
+        for output in &outputs {
             let temp_recipe = TemporaryRenderedRecipe::from_output(&output)?;
             let tool_config = &tool_config;
             let output = temp_recipe
                 .within_context_async(move || async move {
                     output
+                        .clone()
                         .resolve_dependencies(tool_config)
                         .await
                         .into_diagnostic()
@@ -170,18 +172,27 @@ impl Protocol for RattlerBuildBackend {
                 &jinja,
             );
 
+            let depends = finalized_deps.depends.iter().map(DependencyInfo::spec);
+
+            let sources_names = outputs
+                .iter()
+                .cartesian_product(depends.clone())
+                .filter_map(|(output, depend)| {
+                    if Some(output.name()) == depend.name.as_ref() {
+                        Some(output.name())
+                    } else {
+                        None
+                    }
+                })
+                .collect_vec();
+
             let conda = CondaPackageMetadata {
                 name: output.name().clone(),
                 version: output.version().clone(),
                 build: build_string.to_string(),
                 build_number: output.recipe.build.number,
                 subdir: output.build_configuration.target_platform,
-                depends: finalized_deps
-                    .depends
-                    .iter()
-                    .map(DependencyInfo::spec)
-                    .map(MatchSpec::to_string)
-                    .collect(),
+                depends: depends.map(MatchSpec::to_string).collect(),
                 constraints: finalized_deps
                     .constraints
                     .iter()
@@ -191,7 +202,7 @@ impl Protocol for RattlerBuildBackend {
                 license: output.recipe.about.license.map(|l| l.to_string()),
                 license_family: output.recipe.about.license_family,
                 noarch: output.recipe.build.noarch,
-                sources: HashMap::new(),
+                sources: todo!("Build up source records"),
             };
             solved_packages.push(conda);
         }
@@ -495,11 +506,11 @@ mod tests {
     };
 
     use pixi_build_types::{
+        ChannelConfiguration,
         procedures::{
             conda_build::CondaBuildParams, conda_metadata::CondaMetadataParams,
             initialize::InitializeParams,
         },
-        ChannelConfiguration,
     };
     use rattler_build::console_utils::LoggingOutputHandler;
     use tempfile::tempdir;

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -189,7 +189,8 @@ impl Protocol for RattlerBuildBackend {
                     (
                         name.as_source().to_string(),
                         SourcePackageSpecV1::Path(pixi_build_types::PathSpecV1 {
-                            path: self.manifest_root.display().to_string(),
+                            // FIXME
+                            path: ".".to_string(),
                         }),
                     )
                 })

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -189,7 +189,7 @@ impl Protocol for RattlerBuildBackend {
                     (
                         name.as_source().to_string(),
                         SourcePackageSpecV1::Path(pixi_build_types::PathSpecV1 {
-                            // FIXME
+                            // Our source dependency lives in the same recipe
                             path: ".".to_string(),
                         }),
                     )

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -144,7 +144,7 @@ impl Protocol for RattlerBuildBackend {
         let mut solved_packages = vec![];
 
         for output in &outputs {
-            let temp_recipe = TemporaryRenderedRecipe::from_output(&output)?;
+            let temp_recipe = TemporaryRenderedRecipe::from_output(output)?;
             let tool_config = &tool_config;
             let output = temp_recipe
                 .within_context_async(move || async move {
@@ -212,7 +212,7 @@ impl Protocol for RattlerBuildBackend {
                 license: output.recipe.about.license.map(|l| l.to_string()),
                 license_family: output.recipe.about.license_family,
                 noarch: output.recipe.build.noarch,
-                sources: sources,
+                sources,
             };
             solved_packages.push(conda);
         }


### PR DESCRIPTION
Fix multi-output handling of `recipe.yaml`.

- `pixi-build-rattler-build` used to return an empty hashmap for `sources`
- However, a recipe output can depend on an output in the same recipe
- Since Pixi requires all source dependencies to either be directly requested or be transitively requested in the `sources` field, the missing `sources` entry lead to a permanently out-of-date lock file

We should merge in the following order:
- https://github.com/prefix-dev/pixi/pull/3961
- https://github.com/prefix-dev/pixi-build-backends/pull/203
- https://github.com/prefix-dev/pixi-build-testsuite/pull/5