### PR TITLE
fix: add python exe cmake arg when python in host deps

### DIFF
--- a/crates/pixi-build-cmake/src/build_script.j2
+++ b/crates/pixi-build-cmake/src/build_script.j2
@@ -10,6 +10,9 @@ if not exist %SRC_DIR%\..\build\build.ninja (
           -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
           -DBUILD_SHARED_LIBS=ON ^
+          {% if has_host_python -%}
+          -DPython_EXECUTABLE="%PYTHON%" ^
+          {% endif -%}
           {{ extra_args | join(" ") }} ^
           -B %SRC_DIR%\..\build ^
           -S "{{ source_dir }}"
@@ -26,6 +29,9 @@ if [ ! -f "$SRC_DIR/../build/build.ninja" ]; then
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=$PREFIX \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          {% if has_host_python -%}
+          -DPython_EXECUTABLE=$PYTHON \
+          {% endif -%}
           -DBUILD_SHARED_LIBS=ON \
           {{ extra_args | join(" ") }} \
           -B $SRC_DIR/../build \

--- a/crates/pixi-build-cmake/src/build_script.rs
+++ b/crates/pixi-build-cmake/src/build_script.rs
@@ -6,6 +6,10 @@ pub struct BuildScriptContext {
     pub build_platform: BuildPlatform,
     pub source_dir: String,
     pub extra_args: Vec<String>,
+    /// The package has a host dependency on Python.
+    /// This is used to determine if the build script
+    /// should include Python-related logic.
+    pub has_host_python: bool,
 }
 
 #[derive(Serialize)]

--- a/crates/pixi-build-cmake/src/cmake.rs
+++ b/crates/pixi-build-cmake/src/cmake.rs
@@ -114,6 +114,13 @@ impl<P: ProjectModel> CMakeBuildBackend<P> {
 
         let build_platform = Platform::current();
         let build_number = 0;
+        
+        // Check if the host platform has a host python dependency
+        // This is used to determine if we need to the cmake argument for the python executable
+        let has_host_python = self
+            .project_model
+            .dependencies(Some(host_platform))
+            .contains(&"python".into());
 
         let build_script = BuildScriptContext {
             build_platform: if build_platform.is_windows() {
@@ -123,6 +130,7 @@ impl<P: ProjectModel> CMakeBuildBackend<P> {
             },
             source_dir: self.manifest_root.display().to_string(),
             extra_args: self.config.extra_args.clone(),
+            has_host_python,
         }
         .render();
 
@@ -416,5 +424,43 @@ mod tests {
         );
 
         assert_eq!(recipe.build.script.env, env);
+    }
+
+    #[test]
+    fn test_python_host_dependency() {
+        let manifest_source = r#"
+        [workspace]
+        platforms = []
+        channels = []
+        preview = ["pixi-build"]
+
+        [package]
+        name = "foobar"
+        version = "0.1.0"
+
+        [package.host-dependencies]
+        python = "*"
+
+        [package.build]
+        backend = { name = "pixi-build-cmake", version = "*" }
+        "#;
+
+        let recipe = recipe(
+            manifest_source,
+            CMakeBackendConfig {
+                ..Default::default()
+            },
+        );
+
+        let command = match recipe
+            .build
+            .script
+            .content {
+                rattler_build::recipe::parser::ScriptContent::Commands(items) => items,
+                 _ => unreachable!("Expected script content to be commands"),
+            };
+        
+        assert!(command.iter().any(|s| s.contains("-DPython_EXECUTABLE")));
+       
     }
 }


### PR DESCRIPTION
While testing the windows builds, we figured out that it requires `-DPython_EXECUTABLE` to be set. 

This code adds that automatically when `python` is part of the host dependencies. 

You can override it by just setting it in the `extra-args` as the later argument wins in cmake. 

