### PR TITLE
docs: change configuration to list

### DIFF
--- a/docs/backends/pixi-build-cmake.md
+++ b/docs/backends/pixi-build-cmake.md
@@ -55,8 +55,8 @@ You can customize the CMake backend behavior using the `[package.build.configura
 
 ### `extra-args`
 
-**Type**: `Array<String>`
-**Default**: `[]`
+- **Type**: `Array<String>`
+- **Default**: `[]`
 
 Additional command-line arguments to pass to the CMake configuration step. These arguments are inserted into the `cmake` command that configures your project.
 
@@ -70,8 +70,8 @@ extra-args = [
 
 ### `env`
 
-**Type**: `Map<String, String>`
-**Default**: `{}`
+- **Type**: `Map<String, String>`
+- **Default**: `{}`
 
 Environment variables to set during the build process. These variables are available to both the CMake configuration and build steps.
 
@@ -82,8 +82,8 @@ env = { CMAKE_VERBOSE_MAKEFILE = "ON", CXXFLAGS = "-O3 -march=native" }
 
 ### `debug-dir`
 
-**Type**: `String` (path)
-**Default**: Not set
+- **Type**: `String` (path)
+- **Default**: Not set
 
 If specified, internal build state and debug information will be written to this directory. Useful for troubleshooting build issues.
 

--- a/docs/backends/pixi-build-python.md
+++ b/docs/backends/pixi-build-python.md
@@ -60,8 +60,8 @@ You can customize the Python backend behavior using the `[package.build.configur
 
 ### `noarch`
 
-**Type**: `Boolean`
-**Default**: `true`
+- **Type**: `Boolean`
+- **Default**: `true`
 
 Controls whether to build a platform-independent (noarch) package or a platform-specific package. Most pure Python packages should be `noarch` and therefore don't need to set this option since the default is `noarch = true`.
 
@@ -72,8 +72,8 @@ noarch = false  # Build platform-specific package
 
 ### `env`
 
-**Type**: `Map<String, String>`
-**Default**: `{}`
+- **Type**: `Map<String, String>`
+- **Default**: `{}`
 
 Environment variables to set during the build process. These variables are available during package installation.
 
@@ -84,8 +84,8 @@ env = { SETUPTOOLS_SCM_PRETEND_VERSION = "1.0.0" }
 
 ### `debug-dir`
 
-**Type**: `String` (path)
-**Default**: Not set
+- **Type**: `String` (path)
+- **Default**: Not set
 
 If specified, internal build state and debug information will be written to this directory. Useful for troubleshooting build issues.
 

--- a/docs/backends/pixi-build-rattler-build.md
+++ b/docs/backends/pixi-build-rattler-build.md
@@ -49,8 +49,9 @@ Learn more about the `rattler-build`, and its recipe format in its [high level o
 The rattler-build backend supports the following TOML configuration options:
 
 ### `debug-dir`
-- **Type**: String (path)
-- **Default**: None
+
+- **Type**: `String` (path)
+- **Default**: Not set
 
 If specified, internal build state and debug information will be written to this directory. Useful for troubleshooting build issues.
 

--- a/docs/backends/pixi-build-rust.md
+++ b/docs/backends/pixi-build-rust.md
@@ -54,8 +54,8 @@ You can customize the Rust backend behavior using the `[package.build.configurat
 
 ### `extra-args`
 
-**Type**: `Array<String>`
-**Default**: `[]`
+- **Type**: `Array<String>`
+- **Default**: `[]`
 
 Additional command-line arguments to pass to the `cargo install` command. These arguments are appended to the cargo command that builds and installs your project.
 
@@ -69,8 +69,8 @@ extra-args = [
 
 ### `env`
 
-**Type**: `Map<String, String>`
-**Default**: `{}`
+- **Type**: `Map<String, String>`
+- **Default**: `{}`
 
 Environment variables to set during the build process. These variables are available during compilation.
 
@@ -81,8 +81,8 @@ env = { RUST_LOG = "debug", CARGO_PROFILE_RELEASE_LTO = "true" }
 
 ### `debug-dir`
 
-**Type**: `String` (path)
-**Default**: Not set
+- **Type**: `String` (path)
+- **Default**: Not set
 
 If specified, internal build state and debug information will be written to this directory. Useful for troubleshooting build issues.
 


### PR DESCRIPTION
That way it's a bit more readable