### PR TITLE
ci: add timeout to more jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: [format_and_lint]
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@main

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -6,6 +6,7 @@ on:
 
 name: Testsuite
 
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -20,6 +21,7 @@ jobs:
   build-binary-linux-x86_64:
     name: Build Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@main
@@ -45,6 +47,7 @@ jobs:
   build-binary-windows-x86_64:
     name: Build Windows
     runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Create Dev Drive
@@ -77,6 +80,7 @@ jobs:
   build-binary-macos-aarch64:
     name: Build macOS
     runs-on: macos-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@main
@@ -100,10 +104,10 @@ jobs:
           retention-days: 60
 
   test-linux-x86_64:
-    timeout-minutes: 10
     name: Test Linux x86_64
     runs-on: ubuntu-latest
     needs: build-binary-linux-x86_64
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -135,10 +139,10 @@ jobs:
           BUILD_BACKENDS_BIN_DIR: ${{ github.workspace }}/artifacts
 
   test-windows-x86_64:
-    timeout-minutes: 10
     name: Test Windows x86_64
     runs-on: windows-latest
     needs: build-binary-windows-x86_64
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -177,10 +181,10 @@ jobs:
           BUILD_BACKENDS_BIN_DIR: ${{ env.PIXI_WORKSPACE }}/artifacts
 
   test-macos-aarch64:
-    timeout-minutes: 10
     name: Test macOS aarch64
     runs-on: macos-14
     needs: build-binary-macos-aarch64
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
We had a macOS job running for 6h yesterday. We should really avoid that.