### PR TITLE
feat: move build script to Python for `pixi-build-rust`

### DIFF
--- a/crates/pixi-build-backend/src/compilers.rs
+++ b/crates/pixi-build-backend/src/compilers.rs
@@ -10,6 +10,7 @@ pub enum Language<'a> {
     Cxx,
     Fortran,
     Rust,
+    Python,
     Other(&'a str),
 }
 
@@ -20,6 +21,7 @@ impl Display for Language<'_> {
             Language::Cxx => write!(f, "cxx"),
             Language::Fortran => write!(f, "fortran"),
             Language::Rust => write!(f, "rust"),
+            Language::Python => write!(f, "python"),
             Language::Other(name) => write!(f, "{}", name),
         }
     }

--- a/crates/pixi-build-rust/src/build_script.rs
+++ b/crates/pixi-build-rust/src/build_script.rs
@@ -14,9 +14,6 @@ pub struct BuildScriptContext {
 
     /// True if `sccache` is available.
     pub has_sccache: bool,
-
-    /// The platform that is running the build.
-    pub is_bash: bool,
 }
 
 impl BuildScriptContext {
@@ -39,56 +36,41 @@ mod test {
     use rstest::*;
 
     #[rstest]
-    fn test_build_script(#[values(true, false)] is_bash: bool) {
+    fn test_build_script() {
         let context = super::BuildScriptContext {
             source_dir: String::from("my-prefix-dir"),
             extra_args: vec![],
             has_openssl: false,
             has_sccache: false,
-            is_bash,
         };
         let script = context.render();
 
-        let mut settings = insta::Settings::clone_current();
-        settings.set_snapshot_suffix(if is_bash { "bash" } else { "cmdexe" });
-        settings.bind(|| {
-            insta::assert_snapshot!(script.join("\n"));
-        });
+        insta::assert_snapshot!(script.join("\n"));
     }
 
     #[rstest]
-    fn test_sccache(#[values(true, false)] is_bash: bool) {
+    fn test_sccache() {
         let context = super::BuildScriptContext {
             source_dir: String::from("my-prefix-dir"),
             extra_args: vec![],
             has_openssl: false,
             has_sccache: true,
-            is_bash,
         };
         let script = context.render();
 
-        let mut settings = insta::Settings::clone_current();
-        settings.set_snapshot_suffix(if is_bash { "bash" } else { "cmdexe" });
-        settings.bind(|| {
-            insta::assert_snapshot!(script.join("\n"));
-        });
+        insta::assert_snapshot!(script.join("\n"));
     }
 
     #[rstest]
-    fn test_openssl(#[values(true, false)] is_bash: bool) {
+    fn test_openssl() {
         let context = super::BuildScriptContext {
             source_dir: String::from("my-prefix-dir"),
             extra_args: vec![],
             has_openssl: true,
             has_sccache: false,
-            is_bash,
         };
         let script = context.render();
 
-        let mut settings = insta::Settings::clone_current();
-        settings.set_snapshot_suffix(if is_bash { "bash" } else { "cmdexe" });
-        settings.bind(|| {
-            insta::assert_snapshot!(script.join("\n"));
-        });
+        insta::assert_snapshot!(script.join("\n"));
     }
 }

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -55,6 +55,18 @@ impl GenerateRecipe for RustGenerator {
             requirements.build.push(compiler_function.clone());
         }
 
+        if !resolved_requirements
+            .build
+            .contains_key(&PackageName::new_unchecked(Language::Python.to_string()))
+        {
+            requirements.build.push(
+                Language::Python
+                    .to_string()
+                    .parse()
+                    .expect("Should always be able to parse"),
+            );
+        }
+
         let has_openssl = resolved_requirements.contains(&"openssl".parse().into_diagnostic()?);
 
         let mut has_sccache = false;

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -90,13 +90,13 @@ impl GenerateRecipe for RustGenerator {
             extra_args: config.extra_args.clone(),
             has_openssl,
             has_sccache,
-            is_bash: !Platform::current().is_windows(),
         }
         .render();
 
         generated_recipe.recipe.build.script = Script {
             content: build_script,
             env: config.env.clone(),
+            interpreter: Some("python".to_string()),
         };
 
         Ok(generated_recipe)

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__build_script.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__build_script.snap
@@ -1,0 +1,23 @@
+---
+source: crates/pixi-build-rust/src/build_script.rs
+expression: "script.join(\"\\n\")"
+---
+import os
+import subprocess
+import sys
+# Set environment variables
+env = os.environ.copy()
+# Build cargo install command
+cmd = [
+    "cargo", "install", 
+    "--locked", 
+    "--root", os.environ["PREFIX"],
+    "--path", "my-prefix-dir",
+    "--no-track",
+    "--force"
+]
+# Add extra arguments
+# Run cargo install
+result = subprocess.run(cmd, env=env)
+if result.returncode != 0:
+    sys.exit(result.returncode)

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
@@ -1,5 +1,0 @@
----
-source: crates/pixi-build-rust/src/build_script.rs
-expression: "script.join(\"\\n\")"
----
-cargo install --locked --root "$PREFIX" --path my-prefix-dir --no-track  --force

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
@@ -1,6 +1,0 @@
----
-source: crates/pixi-build-rust/src/build_script.rs
-expression: "script.join(\"\\n\")"
----
-cargo install --locked --root "%PREFIX%" --path my-prefix-dir --no-track  --force
-if errorlevel 1 exit 1

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__openssl.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__openssl.snap
@@ -1,38 +1,24 @@
+---
+source: crates/pixi-build-rust/src/build_script.rs
+expression: "script.join(\"\\n\")"
+---
 import os
 import subprocess
 import sys
-
 # Set environment variables
 env = os.environ.copy()
-
-{%- if has_openssl %}
 env["OPENSSL_DIR"] = os.environ["PREFIX"]
-{%- endif %}
-{%- if has_sccache %}
-env["RUSTC_WRAPPER"] = "sccache"
-{%- endif %}
-
 # Build cargo install command
 cmd = [
-    "cargo", "install",
-    "--locked",
+    "cargo", "install", 
+    "--locked", 
     "--root", os.environ["PREFIX"],
-    "--path", "{{ source_dir }}",
+    "--path", "my-prefix-dir",
     "--no-track",
     "--force"
 ]
-
 # Add extra arguments
-{%- if extra_args %}
-cmd.extend({{ extra_args | tojson }})
-{%- endif %}
-
 # Run cargo install
 result = subprocess.run(cmd, env=env)
 if result.returncode != 0:
     sys.exit(result.returncode)
-
-{%- if has_sccache %}
-# Show sccache stats
-subprocess.run(["sccache", "--show-stats"])
-{%- endif %}

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
@@ -1,6 +1,0 @@
----
-source: crates/pixi-build-rust/src/build_script.rs
-expression: "script.join(\"\\n\")"
----
-export OPENSSL_DIR="$PREFIX"
-cargo install --locked --root "$PREFIX" --path my-prefix-dir --no-track  --force

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
@@ -1,7 +1,0 @@
----
-source: crates/pixi-build-rust/src/build_script.rs
-expression: "script.join(\"\\n\")"
----
-SET OPENSSL_DIR="%PREFIX%"
-cargo install --locked --root "%PREFIX%" --path my-prefix-dir --no-track  --force
-if errorlevel 1 exit 1

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__sccache.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__sccache.snap
@@ -1,38 +1,26 @@
+---
+source: crates/pixi-build-rust/src/build_script.rs
+expression: "script.join(\"\\n\")"
+---
 import os
 import subprocess
 import sys
-
 # Set environment variables
 env = os.environ.copy()
-
-{%- if has_openssl %}
-env["OPENSSL_DIR"] = os.environ["PREFIX"]
-{%- endif %}
-{%- if has_sccache %}
 env["RUSTC_WRAPPER"] = "sccache"
-{%- endif %}
-
 # Build cargo install command
 cmd = [
-    "cargo", "install",
-    "--locked",
+    "cargo", "install", 
+    "--locked", 
     "--root", os.environ["PREFIX"],
-    "--path", "{{ source_dir }}",
+    "--path", "my-prefix-dir",
     "--no-track",
     "--force"
 ]
-
 # Add extra arguments
-{%- if extra_args %}
-cmd.extend({{ extra_args | tojson }})
-{%- endif %}
-
 # Run cargo install
 result = subprocess.run(cmd, env=env)
 if result.returncode != 0:
     sys.exit(result.returncode)
-
-{%- if has_sccache %}
 # Show sccache stats
 subprocess.run(["sccache", "--show-stats"])
-{%- endif %}

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
@@ -1,7 +1,0 @@
----
-source: crates/pixi-build-rust/src/build_script.rs
-expression: "script.join(\"\\n\")"
----
-export RUSTC_WRAPPER=sccache
-cargo install --locked --root "$PREFIX" --path my-prefix-dir --no-track  --force
-sccache --show-stats

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
@@ -1,8 +1,0 @@
----
-source: crates/pixi-build-rust/src/build_script.rs
-expression: "script.join(\"\\n\")"
----
-SET RUSTC_WRAPPER=sccache
-cargo install --locked --root "%PREFIX%" --path my-prefix-dir --no-track  --force
-if errorlevel 1 exit 1
-sccache --show-stats

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__tests__env_vars_are_set.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__tests__env_vars_are_set.snap
@@ -5,3 +5,4 @@ expression: generated_recipe.recipe.build.script
 content: "[ ... script ... ]"
 env:
   foo: bar
+interpreter: python

--- a/crates/recipe-stage0/src/recipe.rs
+++ b/crates/recipe-stage0/src/recipe.rs
@@ -417,6 +417,8 @@ pub struct PathSource {
 pub struct Script {
     pub content: Vec<String>,
     pub env: IndexMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interpreter: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -432,6 +434,7 @@ impl Build {
             script: Script {
                 content,
                 env: IndexMap::new(),
+                interpreter: None,
             },
         }
     }


### PR DESCRIPTION
While working on https://github.com/prefix-dev/pixi-build-backends/pull/233, I've noticed that things become unwieldy quickly.

Moving to Python makes things much nicer.
I think we should also do the same for `pixi-build-python`. `pixi-build-cmake` is different since expansion of `CMAKE_ARGS` is useful there, and you kind of need a shell for that.