### PR TITLE
fix: recipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,6 +3948,7 @@ dependencies = [
  "rattler_conda_types",
  "recipe-stage0",
  "serde",
+ "serde_json",
  "tokio",
  "toml_edit 0.22.27",
 ]
@@ -3989,6 +3990,7 @@ dependencies = [
  "recipe-stage0",
  "rstest",
  "serde",
+ "serde_json",
  "temp-env",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-cmake"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "indexmap 2.10.0",
  "insta",
@@ -3936,57 +3936,29 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-python"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "async-trait",
- "chrono",
- "clap",
- "clap-verbosity-flag",
- "dirs",
- "fs-err",
  "indexmap 2.10.0",
  "insta",
- "itertools 0.14.0",
- "jsonrpc-core",
- "jsonrpc-http-server",
- "jsonrpc-stdio-server",
- "log",
  "miette",
  "minijinja",
- "parking_lot 0.12.4",
- "pathdiff",
  "pixi-build-backend",
- "pixi_build_type_conversions",
  "pixi_build_types",
- "pixi_consts",
- "pixi_manifest",
- "pixi_spec",
  "pyproject-toml",
- "rattler-build",
  "rattler_conda_types",
- "rattler_package_streaming",
- "rattler_virtual_packages",
  "recipe-stage0",
- "reqwest",
- "reqwest-middleware",
  "serde",
- "serde_json",
- "serde_yaml",
- "tempfile",
  "tokio",
  "toml_edit 0.22.27",
- "tracing-subscriber",
- "url",
 ]
 
 [[package]]
 name = "pixi-build-rattler-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
  "fs-err",
- "indexmap 2.10.0",
  "insta",
  "itertools 0.14.0",
  "miette",
@@ -4005,29 +3977,19 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-rust"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "async-trait",
- "chrono",
  "indexmap 2.10.0",
  "insta",
- "marked-yaml",
  "miette",
  "minijinja",
  "pixi-build-backend",
- "pixi_build_type_conversions",
  "pixi_build_types",
- "pixi_manifest",
- "rattler-build",
  "rattler_conda_types",
- "rattler_package_streaming",
  "recipe-stage0",
  "rstest",
  "serde",
- "serde_json",
- "serde_yaml",
  "temp-env",
- "tempfile",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ dirs = "6.0.0"
 pathdiff = "0.2.3"
 thiserror = "2.0.12"
 strum = "0.27.2"
+temp-env = "0.3.6"
 
 jsonrpc-stdio-server = "18.0.0"
 jsonrpc-http-server = "18.0.0"

--- a/crates/pixi-build-cmake/Cargo.toml
+++ b/crates/pixi-build-cmake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi-build-cmake"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 
 [dependencies]

--- a/crates/pixi-build-python/Cargo.toml
+++ b/crates/pixi-build-python/Cargo.toml
@@ -1,49 +1,21 @@
 [package]
 name = "pixi-build-python"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
-chrono = { workspace = true }
-clap = { workspace = true, features = ["derive", "env"] }
-clap-verbosity-flag = { workspace = true }
-fs-err = { workspace = true }
 indexmap = { workspace = true }
-itertools = { workspace = true }
-log = { workspace = true }
 miette = { workspace = true }
 minijinja = { workspace = true }
-parking_lot = { workspace = true }
 rattler_conda_types = { workspace = true }
-rattler_package_streaming = { workspace = true }
-rattler_virtual_packages = { workspace = true }
-rattler-build = { workspace = true }
-reqwest = { workspace = true }
-reqwest-middleware = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_yaml = { workspace = true }
-serde_json = { workspace = true }
 toml_edit = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
-tracing-subscriber = { workspace = true }
-url = { workspace = true }
 pyproject-toml = { workspace = true }
-dirs = { workspace = true }
-pathdiff = { workspace = true }
 
 pixi-build-backend = { workspace = true }
 
 pixi_build_types = { workspace = true }
-pixi_consts = { workspace = true }
-pixi_manifest = { workspace = true }
-pixi_spec = { workspace = true }
-pixi_build_type_conversions = { workspace = true }
-
-jsonrpc-stdio-server = { workspace = true }
-jsonrpc-http-server = { workspace = true }
-jsonrpc-core = { workspace = true }
 
 recipe-stage0 = { workspace = true }
 

--- a/crates/pixi-build-python/Cargo.toml
+++ b/crates/pixi-build-python/Cargo.toml
@@ -20,5 +20,6 @@ pixi_build_types = { workspace = true }
 recipe-stage0 = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.42.1", features = ["yaml", "redactions", "filters"] }
-toml_edit = { version = "0.22.24" }
+insta = { workspace = true, features = ["yaml", "redactions", "filters"] }
+toml_edit = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/pixi-build-rattler-build/Cargo.toml
+++ b/crates/pixi-build-rattler-build/Cargo.toml
@@ -25,3 +25,4 @@ chrono = "0.4.41"
 
 [dev-dependencies]
 insta = { workspace = true, features = ["json", "glob"] }
+serde_json = { workspace = true }

--- a/crates/pixi-build-rattler-build/Cargo.toml
+++ b/crates/pixi-build-rattler-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi-build-rattler-build"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 
 [dependencies]
@@ -15,7 +15,6 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 url = { workspace = true }
-indexmap = { workspace = true }
 pathdiff = { workspace = true }
 itertools = { workspace = true }
 

--- a/crates/pixi-build-rust/Cargo.toml
+++ b/crates/pixi-build-rust/Cargo.toml
@@ -18,6 +18,7 @@ recipe-stage0 = { workspace = true }
 
 
 [dev-dependencies]
-insta = { version = "1.42.1", features = ["yaml", "redactions", "filters"] }
+insta = { workspace = true, features = ["yaml", "redactions", "filters"] }
 rstest = { workspace = true }
-temp-env = "0.3.6"
+temp-env = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/pixi-build-rust/Cargo.toml
+++ b/crates/pixi-build-rust/Cargo.toml
@@ -1,34 +1,23 @@
 [package]
 name = "pixi-build-rust"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
-chrono = { workspace = true }
 indexmap = { workspace = true }
 miette = { workspace = true }
 minijinja = { workspace = true, features = ["json"] }
 rattler_conda_types = { workspace = true }
-rattler_package_streaming = { workspace = true }
-rattler-build = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 
 pixi-build-backend = { workspace = true }
-
 pixi_build_types = { workspace = true }
-pixi_manifest = { workspace = true }
-pixi_build_type_conversions = { workspace = true }
 
 recipe-stage0 = { workspace = true }
 
-marked-yaml = "0.8.0"
 
 [dev-dependencies]
 insta = { version = "1.42.1", features = ["yaml", "redactions", "filters"] }
 rstest = { workspace = true }
-serde_yaml = "0.9.34"
 temp-env = "0.3.6"

--- a/recipe/pixi-build-cmake.yaml
+++ b/recipe/pixi-build-cmake.yaml
@@ -10,20 +10,6 @@ package:
 source:
   path: ..
 
-requirements:
-  build:
-    - ${{ compiler("rust") }}
-    - cargo-bundle-licenses
-    - cargo-auditable
-  host:
-    - pkg-config
-    - libzlib
-    - liblzma
-    - if: unix
-      then: openssl
-  run:
-    - pixi-build-api-version >=0,<2
-
 build:
   script:
     env:
@@ -44,6 +30,20 @@ build:
   files:
     - bin/${{ name }}
     - bin/${{ name }}.exe
+
+requirements:
+  build:
+    - ${{ compiler("rust") }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+  host:
+    - pkg-config
+    - libzlib
+    - liblzma
+    - if: unix
+      then: openssl
+  run:
+    - pixi-build-api-version >=0,<2
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-python.yaml
+++ b/recipe/pixi-build-python.yaml
@@ -10,20 +10,6 @@ package:
 source:
   path: ..
 
-requirements:
-  build:
-    - ${{ compiler("rust") }}
-    - cargo-bundle-licenses
-    - cargo-auditable
-  host:
-    - pkg-config
-    - libzlib
-    - liblzma
-    - if: unix
-      then: openssl
-  run:
-    - pixi-build-api-version >=0,<2
-
 build:
   script:
     env:
@@ -44,6 +30,20 @@ build:
   files:
     - bin/${{ name }}
     - bin/${{ name }}.exe
+
+requirements:
+  build:
+    - ${{ compiler("rust") }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+  host:
+    - pkg-config
+    - libzlib
+    - liblzma
+    - if: unix
+      then: openssl
+  run:
+    - pixi-build-api-version >=0,<2
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-rattler-build.yaml
+++ b/recipe/pixi-build-rattler-build.yaml
@@ -8,22 +8,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/prefix-dev/pixi-build-backends/archive/refs/tags/${{name}}-v${{version}}.tar.gz
-  sha256: 8d5b69a931bcbdff64528bfae9f28748f625a70fb5ec93630a5f56196ef9f50c
-
-requirements:
-  build:
-    - ${{ compiler("rust") }}
-    - cargo-bundle-licenses
-    - cargo-auditable
-  host:
-    - pkg-config
-    - libzlib
-    - liblzma
-    - if: unix
-      then: openssl
-  run:
-    - pixi-build-api-version >=0,<2
+  path: ..
 
 build:
   script:
@@ -45,6 +30,20 @@ build:
   files:
     - bin/${{ name }}
     - bin/${{ name }}.exe
+
+requirements:
+  build:
+    - ${{ compiler("rust") }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+  host:
+    - pkg-config
+    - libzlib
+    - liblzma
+    - if: unix
+      then: openssl
+  run:
+    - pixi-build-api-version >=0,<2
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-rust.yaml
+++ b/recipe/pixi-build-rust.yaml
@@ -10,20 +10,6 @@ package:
 source:
   path: ..
 
-requirements:
-  build:
-    - ${{ compiler("rust") }}
-    - cargo-bundle-licenses
-    - cargo-auditable
-  host:
-    - pkg-config
-    - libzlib
-    - liblzma
-    - if: unix
-      then: openssl
-  run:
-    - pixi-build-api-version >=0,<2
-
 build:
   script:
     env:
@@ -44,6 +30,20 @@ build:
   files:
     - bin/${{ name }}
     - bin/${{ name }}.exe
+
+requirements:
+  build:
+    - ${{ compiler("rust") }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+  host:
+    - pkg-config
+    - libzlib
+    - liblzma
+    - if: unix
+      then: openssl
+  run:
+    - pixi-build-api-version >=0,<2
 
 tests:
   - script: ${{ name }} --help


### PR DESCRIPTION
The `pixi-build-rattler-build` recipe had a wrong path. I also aligned more with the conda-forge recipes. Also bumps the versions to `0.3.0` now that we enabled build v1 api.