### PR TITLE
fix: add missing pixi-build-mojo recipe

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -6,6 +6,7 @@ on:
       - "pixi-build-python-v[0-9]+.[0-9]+.[0-9]+"
       - "pixi-build-rattler-build-v[0-9]+.[0-9]+.[0-9]+"
       - "pixi-build-rust-v[0-9]+.[0-9]+.[0-9]+"
+      - "pixi-build-mojo-v[0-9]+.[0-9]+.[0-9]+"
     # Build all backends on main branch
     branches: [main]
   workflow_dispatch:

--- a/recipe/pixi-build-mojo.yaml
+++ b/recipe/pixi-build-mojo.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+context:
+  name: pixi-build-mojo
+  version: "${{ env.get('PIXI_BUILD_MOJO_VERSION', default='0.1.0dev') }}"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  path: ..
+
+build:
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: osx and x86_64
+        then:
+          # use the default linker for osx-64 as we are hitting a bug with the conda-forge linker
+          # https://github.com/rust-lang/rust/issues/140686
+          - unset CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER
+
+      - if: unix
+        then:
+          - export OPENSSL_DIR="$PREFIX"
+      - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path crates/${{name}}
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+  files:
+    - bin/${{ name }}
+    - bin/${{ name }}.exe
+
+requirements:
+  build:
+    - ${{ compiler("rust") }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+  host:
+    - pkg-config
+    - libzlib
+    - liblzma
+    - if: unix
+      then: openssl
+  run:
+    - pixi-build-api-version >=0,<2
+
+tests:
+  - script: ${{ name }} --help
+  - package_contents:
+      bin:
+        - ${{ name }}
+
+about:
+  homepage: https://github.com/prefix-dev/pixi-build-backends
+  summary: A pixi build backend to build Mojo projects.
+  description: |
+    This package provides a build backend for pixi that allows building packages using Mojo.
+  license: BSD-3-Clause
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  documentation: https://prefix-dev.github.io/pixi-build-backends
+  repository: https://github.com/prefix-dev/pixi-build-backends


### PR DESCRIPTION
Adds the mising mojo-backend recipe.

Should I make a change in the mojo-backend code to retrigger CI to build and publish the backend? Or is there another way to re-trigger that?