### PR TITLE
feat: read the finalized dependencies from pixi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "fancy_display"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "console 0.15.11",
 ]
@@ -4068,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "pixi_build_type_conversions"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "itertools 0.14.0",
  "ordermap",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "pixi_build_types"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "ordermap",
  "rattler_conda_types",
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "pixi_config"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "clap",
  "console 0.15.11",
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "pixi_consts"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "console 0.15.11",
  "rattler_cache",
@@ -4133,7 +4133,7 @@ dependencies = [
 [[package]]
 name = "pixi_git"
 version = "0.0.1"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "dashmap",
  "dunce",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "pixi_manifest"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "chrono",
  "console 0.15.11",
@@ -4193,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "pixi_pypi_spec"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "itertools 0.14.0",
  "pep440_rs",
@@ -4213,7 +4213,7 @@ dependencies = [
 [[package]]
 name = "pixi_spec"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "dirs",
  "file_url",
@@ -4236,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "pixi_spec_containers"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.14.0",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "pixi_toml"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "digest",
  "hex",
@@ -4263,7 +4263,7 @@ dependencies = [
 [[package]]
 name = "pixi_utils"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/pixi?branch=main#56f7ebe64a068ae64b31cd44b59af05c566262b8"
+source = "git+https://github.com/prefix-dev/pixi?branch=main#3484c4f8771b322b7a5a5546af3c785de2cd68b3"
 dependencies = [
  "async-fd-lock",
  "fs-err",

--- a/crates/pixi-build-backend/src/intermediate_backend.rs
+++ b/crates/pixi-build-backend/src/intermediate_backend.rs
@@ -1181,11 +1181,23 @@ where
             finalized_dependencies: Some(FinalizedDependencies {
                 build: Some(ResolvedDependencies {
                     specs: vec![],
-                    resolved: vec![],
+                    resolved: params
+                        .build_prefix
+                        .map(|prefix| prefix.packages)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|pkg| pkg.repodata_record)
+                        .collect(),
                 }),
                 host: Some(ResolvedDependencies {
                     specs: vec![],
-                    resolved: vec![],
+                    resolved: params
+                        .host_prefix
+                        .map(|prefix| prefix.packages)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|pkg| pkg.repodata_record)
+                        .collect(),
                 }),
                 run: FinalizedRunDependencies {
                     depends: vec![],

--- a/crates/pixi-build-backend/src/utils/test.rs
+++ b/crates/pixi-build-backend/src/utils/test.rs
@@ -82,6 +82,7 @@ where
         let current_dir = std::env::current_dir().unwrap();
         let result = protocol
             .conda_outputs(CondaOutputsParams {
+                channels: vec![],
                 host_platform,
                 build_platform: host_platform,
                 variant_configuration,


### PR DESCRIPTION
With https://github.com/prefix-dev/pixi/pull/4252 the backends now receive the records installed in the `host`/`build` environments. This PR adds this information to the recipe to ensure that the SP_DIR and PY_VER variables are set during build.