### PR TITLE
Fix/dont copy source

### DIFF
--- a/crates/pixi-build-backend/src/generated_recipe.rs
+++ b/crates/pixi-build-backend/src/generated_recipe.rs
@@ -7,7 +7,7 @@ use std::{
 use pixi_build_types::ProjectModelV1;
 use rattler_build::{NormalizedKey, recipe::variable::Variable};
 use rattler_conda_types::Platform;
-use recipe_stage0::recipe::{ConditionalList, IntermediateRecipe, Item, Package, Source, Value};
+use recipe_stage0::recipe::{IntermediateRecipe, Package, Value};
 use serde::de::DeserializeOwned;
 
 use crate::specs_conversion::from_targets_v1_to_conditional_requirements;
@@ -93,7 +93,7 @@ impl GeneratedRecipe {
     /// Creates a new [`GeneratedRecipe`] from a [`ProjectModelV1`].
     /// A default implementation that doesn't take into account the
     /// build scripts or other fields.
-    pub fn from_model(model: ProjectModelV1, manifest_root: PathBuf) -> Self {
+    pub fn from_model(model: ProjectModelV1) -> Self {
         let package = Package {
             name: Value::Concrete(model.name),
             version: Value::Concrete(
@@ -103,19 +103,11 @@ impl GeneratedRecipe {
             ),
         };
 
-        let manifest_path = match manifest_root.display().to_string() {
-            path if path.is_empty() => String::from("."),
-            path => path,
-        };
-        let source =
-            ConditionalList::from([Item::Value(Value::Concrete(Source::path(manifest_path)))]);
-
         let requirements =
             from_targets_v1_to_conditional_requirements(&model.targets.unwrap_or_default());
 
         let ir = IntermediateRecipe {
             package,
-            source,
             requirements,
             ..Default::default()
         };

--- a/crates/pixi-build-backend/tests/integration/protocol.rs
+++ b/crates/pixi-build-backend/tests/integration/protocol.rs
@@ -56,11 +56,11 @@ mod imp {
             &self,
             model: &pixi_build_types::ProjectModelV1,
             _config: &Self::Config,
-            manifest_path: PathBuf,
+            _manifest_path: PathBuf,
             _host_platform: rattler_conda_types::Platform,
             _python_params: Option<PythonParams>,
         ) -> miette::Result<GeneratedRecipe> {
-            let generated_recipe = GeneratedRecipe::from_model(model.clone(), manifest_path);
+            let generated_recipe = GeneratedRecipe::from_model(model.clone());
             Ok(generated_recipe)
         }
     }

--- a/crates/pixi-build-cmake/src/build_script.j2
+++ b/crates/pixi-build-cmake/src/build_script.j2
@@ -5,7 +5,6 @@
 
 {# - Set up common variables -#}
 {%- set build_dir = "build" -%}
-{%- set source_dir = env("SRC_DIR") -%}
 {%- set library_prefix =  "%LIBRARY_PREFIX%" if build_platform == "windows" else "$PREFIX" -%}
 
 {# Set up default CMake arguments -#}

--- a/crates/pixi-build-cmake/src/main.rs
+++ b/crates/pixi-build-cmake/src/main.rs
@@ -29,8 +29,7 @@ impl GenerateRecipe for CMakeGenerator {
         host_platform: rattler_conda_types::Platform,
         _python_params: Option<PythonParams>,
     ) -> miette::Result<GeneratedRecipe> {
-        let mut generated_recipe =
-            GeneratedRecipe::from_model(model.clone(), manifest_root.clone());
+        let mut generated_recipe = GeneratedRecipe::from_model(model.clone());
 
         // we need to add compilers
 

--- a/crates/pixi-build-mojo/src/main.rs
+++ b/crates/pixi-build-mojo/src/main.rs
@@ -32,8 +32,7 @@ impl GenerateRecipe for MojoGenerator {
         host_platform: rattler_conda_types::Platform,
         _python_params: Option<PythonParams>,
     ) -> miette::Result<GeneratedRecipe> {
-        let mut generated_recipe =
-            GeneratedRecipe::from_model(model.clone(), manifest_root.clone());
+        let mut generated_recipe = GeneratedRecipe::from_model(model.clone());
 
         let cleaned_project_name = clean_project_name(
             generated_recipe

--- a/crates/pixi-build-python/src/main.rs
+++ b/crates/pixi-build-python/src/main.rs
@@ -56,8 +56,7 @@ impl GenerateRecipe for PythonGenerator {
     ) -> miette::Result<GeneratedRecipe> {
         let params = python_params.unwrap_or_default();
 
-        let mut generated_recipe =
-            GeneratedRecipe::from_model(model.clone(), manifest_root.clone());
+        let mut generated_recipe = GeneratedRecipe::from_model(model.clone());
 
         let requirements = &mut generated_recipe.recipe.requirements;
 

--- a/crates/pixi-build-rust/src/build_script.j2
+++ b/crates/pixi-build-rust/src/build_script.j2
@@ -16,7 +16,7 @@ SET {{ key }}={{ value }}
 {{ export("RUSTC_WRAPPER", "sccache") }}
 {%- endif %}
 
-cargo install --locked --root "{{ env("PREFIX") }}" --path {{ source_dir }} --no-track {{ extra_args | join(" ") }} --force
+cargo install --locked --root "{{ env("PREFIX") }}" --path {{ source_dir }} --target-dir target --no-track {{ extra_args | join(" ") }} --force
 {%- if not is_bash %}
 if errorlevel 1 exit 1
 {%- endif %}

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -38,8 +38,7 @@ impl GenerateRecipe for RustGenerator {
         host_platform: Platform,
         _python_params: Option<PythonParams>,
     ) -> miette::Result<GeneratedRecipe> {
-        let mut generated_recipe =
-            GeneratedRecipe::from_model(model.clone(), manifest_root.clone());
+        let mut generated_recipe = GeneratedRecipe::from_model(model.clone());
 
         // we need to add compilers
         let compiler_function = compiler_requirement(&Language::Rust);


### PR DESCRIPTION
Fixes https://github.com/prefix-dev/pixi-build-backends/issues/238

- Stop letting source dirs being copied by rattler-build
- Most backends never used that copied code, only pixi-build-cmake had to be adapted
- While working on that, I've noticed that the Rust target directory is created in the original source directory instead of the work directory, so I adapted this as well