### PR TITLE
fix: variant discovery from recipe

### DIFF
--- a/crates/pixi-build-backend/src/specs_conversion.rs
+++ b/crates/pixi-build-backend/src/specs_conversion.rs
@@ -220,7 +220,7 @@ fn binary_package_spec_to_package_dependency(
 
     // If the version is "*", we treat it as None
     // so later rattler-build can detect the PackageDependency as a variant.
-    let version = version.and_then(|v| if v.to_string() == "*" { None } else { Some(v) });
+    let version = version.filter(|v| v != &rattler_conda_types::VersionSpec::Any);
 
     PackageDependency::Binary(MatchSpec {
         name: Some(name),

--- a/crates/pixi-build-backend/src/specs_conversion.rs
+++ b/crates/pixi-build-backend/src/specs_conversion.rs
@@ -218,6 +218,10 @@ fn binary_package_spec_to_package_dependency(
         license,
     } = binary_spec;
 
+    // If the version is "*", we treat it as None
+    // so later rattler-build can detect the PackageDependency as a variant.
+    let version = version.and_then(|v| if v.to_string() == "*" { None } else { Some(v) });
+
     PackageDependency::Binary(MatchSpec {
         name: Some(name),
         version,
@@ -327,5 +331,16 @@ mod test {
         };
         let match_spec = binary_package_spec_to_package_dependency(name, spec);
         assert_eq!(match_spec.to_string(), "foobar 3.12.*");
+    }
+
+    #[test]
+    fn test_binary_package_conversion_any_is_treated_as_none() {
+        let name = PackageName::new_unchecked("python");
+        let spec = BinaryPackageSpecV1 {
+            version: Some("*".parse().unwrap()),
+            ..BinaryPackageSpecV1::default()
+        };
+        let match_spec = binary_package_spec_to_package_dependency(name, spec);
+        assert_eq!(match_spec.to_string(), "python");
     }
 }

--- a/crates/pixi-build-cmake/src/snapshots/pixi_build_cmake__tests__cxx_is_in_build_requirements.snap
+++ b/crates/pixi-build-cmake/src/snapshots/pixi_build_cmake__tests__cxx_is_in_build_requirements.snap
@@ -17,7 +17,7 @@ requirements:
     - ninja
   host: []
   run:
-    - boltons *
+    - boltons
   run_constraints: []
 tests: []
 about: ~

--- a/crates/pixi-build-cmake/src/snapshots/pixi_build_cmake__tests__cxx_is_not_added_if_gcc_is_already_present.snap
+++ b/crates/pixi-build-cmake/src/snapshots/pixi_build_cmake__tests__cxx_is_not_added_if_gcc_is_already_present.snap
@@ -12,12 +12,12 @@ build:
   script: "[ ... script ... ]"
 requirements:
   build:
-    - gxx *
+    - gxx
     - cmake
     - ninja
   host: []
   run:
-    - boltons *
+    - boltons
   run_constraints: []
 tests: []
 about: ~

--- a/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__max_is_in_build_requirements.snap
+++ b/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__max_is_in_build_requirements.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pixi-build-mojo/src/main.rs
 expression: generated_recipe.recipe
+snapshot_kind: text
 ---
 context: {}
 package:
@@ -15,7 +16,7 @@ requirements:
     - max
   host: []
   run:
-    - boltons *
+    - boltons
   run_constraints: []
 tests: []
 about: ~

--- a/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__max_is_not_added_if_max_is_already_present.snap
+++ b/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__max_is_not_added_if_max_is_already_present.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pixi-build-mojo/src/main.rs
 expression: generated_recipe.recipe
+snapshot_kind: text
 ---
 context: {}
 package:
@@ -12,10 +13,10 @@ build:
   script: "[ ... script ... ]"
 requirements:
   build:
-    - max *
+    - max
   host: []
   run:
-    - boltons *
+    - boltons
   run_constraints: []
 tests: []
 about: ~

--- a/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
+++ b/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pixi-build-mojo/src/main.rs
 expression: generated_recipe.recipe
+snapshot_kind: text
 ---
 context: {}
 package:
@@ -22,7 +23,7 @@ requirements:
     - max
   host: []
   run:
-    - boltons *
+    - boltons
   run_constraints: []
 tests: []
 about: ~

--- a/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
+++ b/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pixi-build-mojo/src/main.rs
 expression: generated_recipe.recipe
+snapshot_kind: text
 ---
 context: {}
 package:
@@ -24,7 +25,7 @@ requirements:
     - max
   host: []
   run:
-    - boltons *
+    - boltons
   run_constraints: []
 tests: []
 about: ~

--- a/crates/pixi-build-python/src/snapshots/pixi_build_python__tests__pip_is_in_host_requirements.snap
+++ b/crates/pixi-build-python/src/snapshots/pixi_build_python__tests__pip_is_in_host_requirements.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pixi-build-python/src/main.rs
 expression: generated_recipe.recipe
+snapshot_kind: text
 ---
 context: {}
 package:
@@ -17,7 +18,7 @@ requirements:
     - pip
     - python
   run:
-    - boltons *
+    - boltons
     - python
   run_constraints: []
 tests: []

--- a/crates/pixi-build-python/src/snapshots/pixi_build_python__tests__python_is_not_added_if_already_present.snap
+++ b/crates/pixi-build-python/src/snapshots/pixi_build_python__tests__python_is_not_added_if_already_present.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pixi-build-python/src/main.rs
 expression: generated_recipe.recipe
+snapshot_kind: text
 ---
 context: {}
 package:
@@ -14,10 +15,10 @@ build:
 requirements:
   build: []
   host:
-    - python *
+    - python
     - pip
   run:
-    - boltons *
+    - boltons
     - python
   run_constraints: []
 tests: []

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__tests__rust_is_in_build_requirements.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__tests__rust_is_in_build_requirements.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pixi-build-rust/src/main.rs
 expression: generated_recipe.recipe
+snapshot_kind: text
 ---
 context: {}
 package:
@@ -15,7 +16,7 @@ requirements:
     - "${{ compiler('rust') }}"
   host: []
   run:
-    - boltons *
+    - boltons
   run_constraints: []
 tests: []
 about: ~

--- a/crates/pixi-build-rust/src/snapshots/pixi_build_rust__tests__rust_is_not_added_if_already_present.snap
+++ b/crates/pixi-build-rust/src/snapshots/pixi_build_rust__tests__rust_is_not_added_if_already_present.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pixi-build-rust/src/main.rs
 expression: generated_recipe.recipe
+snapshot_kind: text
 ---
 context: {}
 package:
@@ -12,10 +13,10 @@ build:
   script: "[ ... script ... ]"
 requirements:
   build:
-    - rust *
+    - rust
   host: []
   run:
-    - boltons *
+    - boltons
   run_constraints: []
 tests: []
 about: ~


### PR DESCRIPTION
## Overview

Previously, rattler-build treated `- python *` as `not` a variant, so we missed it.

This fix will convert from Binary matchspec `python * ` to just `python`, so rattler-build could discover it