### PR TITLE
ci: replace using of the cache logic with writing it

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@main
         with:
-          cache: ${{ github.ref == 'refs/heads/main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
         with:
           workspaces: ". -> target/pixi"
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@main
         with:
-          cache: ${{ github.ref == 'refs/heads/main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
         with:
           workspaces: ". -> target/pixi"

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@main
         with:
-          cache: ${{ github.ref == 'refs/heads/main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
         with:
           workspaces: ". -> target/pixi"
@@ -57,8 +57,8 @@ jobs:
           Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.PIXI_WORKSPACE }}" -Recurse
       - uses: prefix-dev/setup-pixi@main
         with:
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           manifest-path: ${{ env.PIXI_WORKSPACE }}/pixi.toml
-          cache: ${{ github.ref == 'refs/heads/main' }}
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
         with:
           workspaces: ". -> ${{ env.PIXI_WORKSPACE }}/target/pixi"
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@main
         with:
-          cache: ${{ github.ref == 'refs/heads/main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
         with:
           workspaces: ". -> target/pixi"


### PR DESCRIPTION
We were not using the cache for Pixi envs in PRs which resulted in up to 5 minute installations before running the tests. 

This replaces:
```
cache: ${{ github.ref == 'refs/heads/main' }}
```
with
```
cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
```
Meaning we decide if we cache based on the name but using the cache is always turned on. 