### PR TITLE
chore: use mojo-compiler pkg

### DIFF
--- a/crates/pixi-build-mojo/src/main.rs
+++ b/crates/pixi-build-mojo/src/main.rs
@@ -52,11 +52,17 @@ impl GenerateRecipe for MojoGenerator {
 
         // Ensure the compiler function is added to the build requirements
         // only if a specific compiler is not already present.
-        let mojo_compiler_pkg = "max".to_string();
+        let mojo_compiler_pkg = "mojo-compiler".to_string();
+        // All of these packages also contain the mojo compiler and maintain backward compat.
+        // They should be removable at a future point.
+        let alt_names = ["max", "mojo", "modular"];
 
         if !resolved_requirements
             .build
             .contains_key(&PackageName::new_unchecked(&mojo_compiler_pkg))
+            && !alt_names
+                .iter()
+                .any(|alt| resolved_requirements.build.contains_key(*alt))
         {
             requirements
                 .build
@@ -237,7 +243,7 @@ mod tests {
     }
 
     #[test]
-    fn test_max_is_in_build_requirements() {
+    fn test_compiler_is_in_build_requirements() {
         let project_model = project_fixture!({
             "name": "foobar",
             "version": "0.1.0",
@@ -318,7 +324,7 @@ mod tests {
     }
 
     #[test]
-    fn test_max_is_not_added_if_max_is_already_present() {
+    fn test_compiler_is_not_added_if_compiler_is_already_present() {
         let project_model = project_fixture!({
             "name": "foobar",
             "version": "0.1.0",
@@ -332,7 +338,7 @@ mod tests {
                         }
                     },
                     "buildDependencies": {
-                        "max": {
+                        "mojo-compiler": {
                             "binary": {
                                 "version": "*"
                             }

--- a/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__compiler_is_in_build_requirements.snap
+++ b/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__compiler_is_in_build_requirements.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pixi-build-mojo/src/main.rs
 expression: generated_recipe.recipe
-snapshot_kind: text
 ---
 context: {}
 package:
@@ -13,7 +12,7 @@ build:
   script: "[ ... script ... ]"
 requirements:
   build:
-    - max
+    - mojo-compiler
   host: []
   run:
     - boltons

--- a/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__compiler_is_not_added_if_compiler_is_already_present.snap
+++ b/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__compiler_is_not_added_if_compiler_is_already_present.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pixi-build-mojo/src/main.rs
 expression: generated_recipe.recipe
-snapshot_kind: text
 ---
 context: {}
 package:
@@ -13,7 +12,7 @@ build:
   script: "[ ... script ... ]"
 requirements:
   build:
-    - max
+    - mojo-compiler
   host: []
   run:
     - boltons

--- a/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
+++ b/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pixi-build-mojo/src/main.rs
 expression: generated_recipe.recipe
-snapshot_kind: text
 ---
 context: {}
 package:
@@ -20,7 +19,7 @@ build:
     secrets: []
 requirements:
   build:
-    - max
+    - mojo-compiler
   host: []
   run:
     - boltons

--- a/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
+++ b/crates/pixi-build-mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pixi-build-mojo/src/main.rs
 expression: generated_recipe.recipe
-snapshot_kind: text
 ---
 context: {}
 package:
@@ -22,7 +21,7 @@ build:
     secrets: []
 requirements:
   build:
-    - max
+    - mojo-compiler
   host: []
   run:
     - boltons

--- a/docs/backends/pixi-build-mojo.md
+++ b/docs/backends/pixi-build-mojo.md
@@ -80,15 +80,15 @@ backend = { name = "pixi-build-mojo", version = "0.1.*" }
 [tasks]
 
 [package.host-dependencies]
-max = "=25.4.0"
+mojo-compiler = "=25.5.0"
 
 [package.build-dependencies]
-max = "=25.4.0"
+mojo-compiler = "=25.5.0"
 small_time = ">=25.4.1,<26"
 extramojo = ">=0.16.0,<0.17"
 
 [package.run-dependencies]
-max = "=25.4.0"
+mojo-compiler = "=25.5.0"
 
 [dependencies]
 # For running `mojo test` while developing add all dependencies under


### PR DESCRIPTION
With mojo 25.5 out, there is now a stable `mojo-compiler` package to target. This PR keeps backward compat with some of the old package names that people use for the mojo compiler as well.