### PR TITLE
feat: rust backend, read recipe information from `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4070,6 +4070,7 @@ dependencies = [
  "serde_json",
  "temp-env",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee"
 
 [[package]]
+name = "cargo_toml"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
+dependencies = [
+ "serde",
+ "toml 0.9.2",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,6 +4056,7 @@ dependencies = [
 name = "pixi-build-rust"
 version = "0.3.2"
 dependencies = [
+ "cargo_toml",
  "indexmap 2.10.0",
  "insta",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ resolver = "2"
 edition = "2024"
 repository = "https://github.com/prefix-dev/pixi-build-backends"
 license = "BSD-3"
-license-file = "LICENSE"
 
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
+repository = "https://github.com/prefix-dev/pixi-build-backends"
+license = "BSD-3"
+license-file = "LICENSE"
+
 
 [workspace.dependencies]
 async-trait = "0.1.86"

--- a/crates/pixi-build-backend/src/generated_recipe.rs
+++ b/crates/pixi-build-backend/src/generated_recipe.rs
@@ -104,26 +104,26 @@ impl GeneratedRecipe {
     pub fn from_model(
         model: ProjectModelV1,
         provider: Option<impl MetadataProvider>,
-    ) -> Result<Self, GenerateRecipeError> {
-        let version = model
-            .version
-            .or_else(|| provider.as_ref().and_then(|p| p.version().ok()))
-            .ok_or(GenerateRecipeError::NoVersionDefined)?;
-
+    ) -> Result<Self, GenerateRecipeError> {        
+        // If the name is not defined in the model, we try to get it from the provider.
+        // If the provider cannot provide a name, we return an error.
         let name = if model.name.is_empty() {
-            if let Ok(name) = provider
+            provider
                 .as_ref()
-                .map(|p| p.name())
+                .and_then(|p| p.name().ok())
                 .ok_or(GenerateRecipeError::NoNameDefined)?
-            {
-                name
-            } else {
-                return Err(GenerateRecipeError::NoNameDefined);
-            }
         } else {
             model.name
         };
 
+
+        // If the version is not defined in the model, we try to get it from the provider.
+        // If the provider cannot provide a version, we return an error.
+        let version = model
+            .version
+            .or_else(|| provider.as_ref().and_then(|p| p.version().ok()))
+            .ok_or(GenerateRecipeError::NoVersionDefined)?;
+        
         let package = Package {
             name: Value::Concrete(name),
             version: Value::Concrete(version.to_string()),

--- a/crates/pixi-build-backend/src/generated_recipe.rs
+++ b/crates/pixi-build-backend/src/generated_recipe.rs
@@ -103,7 +103,7 @@ impl GeneratedRecipe {
     /// build scripts or other fields.
     pub fn from_model(
         model: ProjectModelV1,
-        provider: Option<impl MetadataProvider>,
+        provider: Option<Box<dyn MetadataProvider>>,
     ) -> Result<Self, GenerateRecipeError> {
         // If the name is not defined in the model, we try to get it from the provider.
         // If the provider cannot provide a name, we return an error.

--- a/crates/pixi-build-backend/src/generated_recipe.rs
+++ b/crates/pixi-build-backend/src/generated_recipe.rs
@@ -104,7 +104,7 @@ impl GeneratedRecipe {
     pub fn from_model(
         model: ProjectModelV1,
         provider: Option<impl MetadataProvider>,
-    ) -> Result<Self, GenerateRecipeError> {        
+    ) -> Result<Self, GenerateRecipeError> {
         // If the name is not defined in the model, we try to get it from the provider.
         // If the provider cannot provide a name, we return an error.
         let name = if model.name.is_empty() {
@@ -116,14 +116,13 @@ impl GeneratedRecipe {
             model.name
         };
 
-
         // If the version is not defined in the model, we try to get it from the provider.
         // If the provider cannot provide a version, we return an error.
         let version = model
             .version
             .or_else(|| provider.as_ref().and_then(|p| p.version().ok()))
             .ok_or(GenerateRecipeError::NoVersionDefined)?;
-        
+
         let package = Package {
             name: Value::Concrete(name),
             version: Value::Concrete(version.to_string()),

--- a/crates/pixi-build-backend/tests/integration/protocol.rs
+++ b/crates/pixi-build-backend/tests/integration/protocol.rs
@@ -16,7 +16,7 @@ use url::Url;
 #[cfg(test)]
 mod imp {
     use std::path::{Path, PathBuf};
-
+    use miette::IntoDiagnostic;
     use pixi_build_backend::generated_recipe::{
         BackendConfig, GenerateRecipe, GeneratedRecipe, PythonParams,
     };
@@ -60,8 +60,7 @@ mod imp {
             _host_platform: rattler_conda_types::Platform,
             _python_params: Option<PythonParams>,
         ) -> miette::Result<GeneratedRecipe> {
-            let generated_recipe = GeneratedRecipe::from_model(model.clone());
-            Ok(generated_recipe)
+            GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()
         }
     }
 }

--- a/crates/pixi-build-backend/tests/integration/protocol.rs
+++ b/crates/pixi-build-backend/tests/integration/protocol.rs
@@ -15,12 +15,12 @@ use url::Url;
 
 #[cfg(test)]
 mod imp {
-    use std::path::{Path, PathBuf};
     use miette::IntoDiagnostic;
     use pixi_build_backend::generated_recipe::{
         BackendConfig, GenerateRecipe, GeneratedRecipe, PythonParams,
     };
     use serde::{Deserialize, Serialize};
+    use std::path::{Path, PathBuf};
 
     #[derive(Debug, Default, Serialize, Deserialize, Clone)]
     #[serde(rename_all = "kebab-case")]

--- a/crates/pixi-build-cmake/Cargo.toml
+++ b/crates/pixi-build-cmake/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "pixi-build-cmake"
 version = "0.3.2"
+description = "CMake build backend for Pixi"
 edition.workspace = true
 
 [dependencies]

--- a/crates/pixi-build-cmake/src/main.rs
+++ b/crates/pixi-build-cmake/src/main.rs
@@ -29,7 +29,8 @@ impl GenerateRecipe for CMakeGenerator {
         host_platform: rattler_conda_types::Platform,
         _python_params: Option<PythonParams>,
     ) -> miette::Result<GeneratedRecipe> {
-        let mut generated_recipe = GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()?;
+        let mut generated_recipe =
+            GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()?;
 
         // we need to add compilers
 

--- a/crates/pixi-build-cmake/src/main.rs
+++ b/crates/pixi-build-cmake/src/main.rs
@@ -29,7 +29,7 @@ impl GenerateRecipe for CMakeGenerator {
         host_platform: rattler_conda_types::Platform,
         _python_params: Option<PythonParams>,
     ) -> miette::Result<GeneratedRecipe> {
-        let mut generated_recipe = GeneratedRecipe::from_model(model.clone());
+        let mut generated_recipe = GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()?;
 
         // we need to add compilers
 

--- a/crates/pixi-build-mojo/src/main.rs
+++ b/crates/pixi-build-mojo/src/main.rs
@@ -32,7 +32,8 @@ impl GenerateRecipe for MojoGenerator {
         host_platform: rattler_conda_types::Platform,
         _python_params: Option<PythonParams>,
     ) -> miette::Result<GeneratedRecipe> {
-        let mut generated_recipe = GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()?;
+        let mut generated_recipe =
+            GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()?;
 
         let cleaned_project_name = clean_project_name(
             generated_recipe

--- a/crates/pixi-build-mojo/src/main.rs
+++ b/crates/pixi-build-mojo/src/main.rs
@@ -32,7 +32,7 @@ impl GenerateRecipe for MojoGenerator {
         host_platform: rattler_conda_types::Platform,
         _python_params: Option<PythonParams>,
     ) -> miette::Result<GeneratedRecipe> {
-        let mut generated_recipe = GeneratedRecipe::from_model(model.clone());
+        let mut generated_recipe = GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()?;
 
         let cleaned_project_name = clean_project_name(
             generated_recipe

--- a/crates/pixi-build-python/src/main.rs
+++ b/crates/pixi-build-python/src/main.rs
@@ -56,7 +56,7 @@ impl GenerateRecipe for PythonGenerator {
     ) -> miette::Result<GeneratedRecipe> {
         let params = python_params.unwrap_or_default();
 
-        let mut generated_recipe = GeneratedRecipe::from_model(model.clone());
+        let mut generated_recipe = GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()?;
 
         let requirements = &mut generated_recipe.recipe.requirements;
 

--- a/crates/pixi-build-python/src/main.rs
+++ b/crates/pixi-build-python/src/main.rs
@@ -56,7 +56,8 @@ impl GenerateRecipe for PythonGenerator {
     ) -> miette::Result<GeneratedRecipe> {
         let params = python_params.unwrap_or_default();
 
-        let mut generated_recipe = GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()?;
+        let mut generated_recipe =
+            GeneratedRecipe::from_model(model.clone(), None).into_diagnostic()?;
 
         let requirements = &mut generated_recipe.recipe.requirements;
 

--- a/crates/pixi-build-rust/Cargo.toml
+++ b/crates/pixi-build-rust/Cargo.toml
@@ -20,6 +20,7 @@ pixi-build-backend = { workspace = true }
 pixi_build_types = { workspace = true }
 
 recipe-stage0 = { workspace = true }
+tracing = "0.1.41"
 
 
 [dev-dependencies]

--- a/crates/pixi-build-rust/Cargo.toml
+++ b/crates/pixi-build-rust/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "pixi-build-rust"
 version = "0.3.2"
+description = "A Rust build backend for Pixi"
+documentation = "https://prefix-dev.github.io/pixi-build-backends/backends/pixi-build-rust/"
+repository.workspace = true
+license.workspace = true
+license-file.workspace = true
 edition.workspace = true
 
 [dependencies]
@@ -10,7 +15,7 @@ minijinja = { workspace = true, features = ["json"] }
 rattler_conda_types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros"] }
-
+cargo_toml = "0.22.3"
 pixi-build-backend = { workspace = true }
 pixi_build_types = { workspace = true }
 

--- a/crates/pixi-build-rust/Cargo.toml
+++ b/crates/pixi-build-rust/Cargo.toml
@@ -5,7 +5,6 @@ description = "A Rust build backend for Pixi"
 documentation = "https://prefix-dev.github.io/pixi-build-backends/backends/pixi-build-rust/"
 repository.workspace = true
 license.workspace = true
-license-file.workspace = true
 edition.workspace = true
 
 [dependencies]

--- a/crates/pixi-build-rust/src/config.rs
+++ b/crates/pixi-build-rust/src/config.rs
@@ -18,6 +18,9 @@ pub struct RustBackendConfig {
     /// Extra input globs to include in addition to the default ones
     #[serde(default)]
     pub extra_input_globs: Vec<String>,
+    /// Ignore the cargo manifest and depend only on the project model.
+    #[serde(default)]
+    pub ignore_cargo_manifest: Option<bool>,
 }
 
 impl BackendConfig for RustBackendConfig {
@@ -53,6 +56,8 @@ impl BackendConfig for RustBackendConfig {
             } else {
                 target_config.extra_input_globs.clone()
             },
+            ignore_cargo_manifest: target_config.ignore_cargo_manifest
+                .or(self.ignore_cargo_manifest),
         })
     }
 }
@@ -81,6 +86,7 @@ mod tests {
             env: base_env,
             debug_dir: Some(PathBuf::from("/base/debug")),
             extra_input_globs: vec!["*.base".to_string()],
+            ignore_cargo_manifest: None,
         };
 
         let mut target_env = indexmap::IndexMap::new();
@@ -92,6 +98,7 @@ mod tests {
             env: target_env,
             debug_dir: None,
             extra_input_globs: vec!["*.target".to_string()],
+            ignore_cargo_manifest: Some(true),
         };
 
         let merged = base_config
@@ -129,6 +136,7 @@ mod tests {
             env: base_env,
             debug_dir: Some(PathBuf::from("/base/debug")),
             extra_input_globs: vec!["*.base".to_string()],
+            ignore_cargo_manifest: None,
         };
 
         let empty_target_config = RustBackendConfig::default();

--- a/crates/pixi-build-rust/src/config.rs
+++ b/crates/pixi-build-rust/src/config.rs
@@ -56,7 +56,8 @@ impl BackendConfig for RustBackendConfig {
             } else {
                 target_config.extra_input_globs.clone()
             },
-            ignore_cargo_manifest: target_config.ignore_cargo_manifest
+            ignore_cargo_manifest: target_config
+                .ignore_cargo_manifest
                 .or(self.ignore_cargo_manifest),
         })
     }

--- a/crates/pixi-build-rust/src/config.rs
+++ b/crates/pixi-build-rust/src/config.rs
@@ -23,6 +23,16 @@ pub struct RustBackendConfig {
     pub ignore_cargo_manifest: Option<bool>,
 }
 
+impl RustBackendConfig {
+    /// Creates a new [`RustBackendConfig`] with default values.
+    pub fn default_with_ignore_cargo_manifest() -> Self {
+        Self {
+            ignore_cargo_manifest: Some(true),
+            ..Default::default()
+        }
+    }
+}
+
 impl BackendConfig for RustBackendConfig {
     fn debug_dir(&self) -> Option<&Path> {
         self.debug_dir.as_deref()

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -117,8 +117,7 @@ impl GenerateRecipe for RustGenerator {
             None
         } else {
             Some(CargoMetadataProvider {
-                cargo_manifest: get_cargo_manifest(&manifest_root)
-                    .into_diagnostic()?,
+                cargo_manifest: get_cargo_manifest(&manifest_root).into_diagnostic()?,
             })
         };
 

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -124,7 +124,7 @@ impl GenerateRecipe for RustGenerator {
             let cargo_manifest = get_cargo_manifest(&manifest_root)
                 .into_diagnostic()
                 .map_err(|e| miette::miette!("Failed to parse Cargo.toml: {e}"))?;
-            
+
             let provider = CargoMetadataProvider { cargo_manifest };
             generated_recipe =
                 GeneratedRecipe::from_model(model.clone(), Some(provider)).into_diagnostic()?;
@@ -482,29 +482,71 @@ mod tests {
 
         // Verify that the about section is populated correctly
         eprintln!("{:#?}", generated_recipe.recipe);
-        
+
         // Manually load the Cargo manifest to ensure it works
         let current_dir = std::env::current_dir().unwrap();
         let package_manifest_path = current_dir.join("Cargo.toml");
         let mut manifest = Manifest::from_path(&package_manifest_path).unwrap();
         manifest.complete_from_path(&package_manifest_path).unwrap();
-        
-        assert_eq!(manifest.clone().package.unwrap().name.clone(), generated_recipe.recipe.package.name.to_string());
+
+        assert_eq!(
+            manifest.clone().package.unwrap().name.clone(),
+            generated_recipe.recipe.package.name.to_string()
+        );
         assert_eq!(
             *manifest.clone().package.unwrap().version.get().unwrap(),
             generated_recipe.recipe.package.version.to_string()
         );
         assert_eq!(
-            *manifest.clone().package.unwrap().description.unwrap().get().unwrap(),
-            generated_recipe.recipe.about.as_ref().and_then(|a| a.description.clone()).unwrap().to_string()
+            *manifest
+                .clone()
+                .package
+                .unwrap()
+                .description
+                .unwrap()
+                .get()
+                .unwrap(),
+            generated_recipe
+                .recipe
+                .about
+                .as_ref()
+                .and_then(|a| a.description.clone())
+                .unwrap()
+                .to_string()
         );
         assert_eq!(
-            *manifest.clone().package.unwrap().license.unwrap().get().unwrap(),
-            generated_recipe.recipe.about.as_ref().and_then(|a| a.license.clone()).unwrap().to_string()
+            *manifest
+                .clone()
+                .package
+                .unwrap()
+                .license
+                .unwrap()
+                .get()
+                .unwrap(),
+            generated_recipe
+                .recipe
+                .about
+                .as_ref()
+                .and_then(|a| a.license.clone())
+                .unwrap()
+                .to_string()
         );
         assert_eq!(
-            *manifest.clone().package.unwrap().repository.unwrap().get().unwrap(),
-            generated_recipe.recipe.about.as_ref().and_then(|a| a.repository.clone()).unwrap().to_string()
+            *manifest
+                .clone()
+                .package
+                .unwrap()
+                .repository
+                .unwrap()
+                .get()
+                .unwrap(),
+            generated_recipe
+                .recipe
+                .about
+                .as_ref()
+                .and_then(|a| a.repository.clone())
+                .unwrap()
+                .to_string()
         );
     }
 }

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -19,13 +19,13 @@ use pixi_build_backend::{
 };
 use pixi_build_types::ProjectModelV1;
 use rattler_conda_types::{PackageName, Platform};
+use recipe_stage0::recipe::Value;
 use recipe_stage0::{
     matchspec::PackageDependency,
     recipe::{Item, Script},
 };
 use std::collections::BTreeSet;
 use std::str::FromStr;
-use recipe_stage0::recipe::Value;
 
 #[derive(Default, Clone)]
 pub struct RustGenerator {}
@@ -162,25 +162,21 @@ fn get_cargo_manifest(manifest_root: &PathBuf) -> Result<Manifest, CargoTomlErro
     })
 }
 
-
-fn merge_cargo_manifest_with_recipe(
-    manifest: Manifest,
-    recipe: &mut GeneratedRecipe,
-) {
+fn merge_cargo_manifest_with_recipe(manifest: Manifest, recipe: &mut GeneratedRecipe) {
     // About section
     if let Some(package) = manifest.package {
         // Create about if missing
         let about = recipe.recipe.about.get_or_insert_with(Default::default);
-        
+
         // Only set values if they are not already set
         if about.description.is_none() {
             if let Some(desc) = &package.description {
-                if let Ok(desc) = desc.get(){
+                if let Ok(desc) = desc.get() {
                     about.description = Some(Value::from_str(desc.as_str()).unwrap());
                 }
             }
         }
-        
+
         if about.documentation.is_none() {
             if let Some(doc) = &package.documentation {
                 if let Ok(doc) = doc.get() {
@@ -188,7 +184,7 @@ fn merge_cargo_manifest_with_recipe(
                 }
             }
         }
-        
+
         if about.repository.is_none() {
             if let Some(repo) = &package.repository {
                 if let Ok(repo) = repo.get() {
@@ -206,11 +202,14 @@ fn merge_cargo_manifest_with_recipe(
         if about.license_file.is_none() {
             if let Some(license_file) = &package.license_file {
                 if let Ok(license_file) = license_file.get() {
-                    about.license_file = Some(Value::from_str(license_file.to_string_lossy().to_string().as_str()).unwrap());
+                    about.license_file = Some(
+                        Value::from_str(license_file.to_string_lossy().to_string().as_str())
+                            .unwrap(),
+                    );
                 }
             }
         }
-        
+
         if about.homepage.is_none() {
             if let Some(homepage) = &package.homepage {
                 if let Ok(homepage) = homepage.get() {
@@ -226,7 +225,6 @@ fn merge_cargo_manifest_with_recipe(
                 }
             }
         }
-        
     }
 }
 
@@ -450,9 +448,9 @@ mod tests {
         let mut manifest = Manifest::from_path(&package_manifest_path).unwrap();
 
         manifest.complete_from_path(&package_manifest_path).unwrap();
-        
+
         eprintln!("{manifest:#?}");
-        
+
         let project_model = project_fixture!({
             "name": "foobar",
             "version": "0.1.0",
@@ -464,14 +462,13 @@ mod tests {
                 },
             }
         });
-        
+
         let mut generated_recipe = GeneratedRecipe::from_model(project_model.clone());
-        
+
         // Merge the Cargo manifest with the recipe
         merge_cargo_manifest_with_recipe(manifest, &mut generated_recipe);
-        
+
         // Verify that the about section is populated correctly
         eprintln!("{:#?}", generated_recipe.recipe.about);
-        
     }
 }

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -45,7 +45,7 @@ impl MetadataProvider for CargoMetadataProvider {
     fn version(&self) -> Result<Version, MetadataProviderError> {
         if let Some(package) = &self.cargo_manifest.package {
             if let Ok(version) = &package.version.get() {
-                Version::from_str(version).map_err(|e| MetadataProviderError::CannotParseVersion(e))
+                Version::from_str(version).map_err(MetadataProviderError::CannotParseVersion)
             } else {
                 Err(MetadataProviderError::CannotProvideVersion)
             }
@@ -193,7 +193,7 @@ impl GenerateRecipe for RustGenerator {
                     .into_iter()
                     .filter(|dep| !existing_reqs.contains(dep)),
             );
-            
+
             has_sccache = true;
         }
 
@@ -236,7 +236,8 @@ impl GenerateRecipe for RustGenerator {
     }
 }
 
-fn get_cargo_manifest(manifest_root: &PathBuf) -> Result<Manifest, CargoTomlError> {
+/// Load the Cargo manifest from the given path.
+fn get_cargo_manifest(manifest_root: &Path) -> Result<Manifest, CargoTomlError> {
     let package_manifest_path = manifest_root.join("Cargo.toml");
 
     Manifest::from_path(&package_manifest_path).and_then(|mut manifest| {

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -134,8 +134,6 @@ impl GenerateRecipe for RustGenerator {
 
         let resolved_requirements = requirements.resolve(Some(host_platform));
 
-        // Mix the Cargo manifest with the recipe
-
         // Ensure the compiler function is added to the build requirements
         // only if it is not already present.
 
@@ -190,6 +188,12 @@ impl GenerateRecipe for RustGenerator {
             // only if they are not already present
             let existing_reqs: Vec<_> = requirements.build.clone().into_iter().collect();
 
+            requirements.build.extend(
+                sccache_dep
+                    .into_iter()
+                    .filter(|dep| !existing_reqs.contains(dep)),
+            );
+            
             has_sccache = true;
         }
 

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -121,8 +121,11 @@ impl GenerateRecipe for RustGenerator {
             })
         };
 
-        let mut generated_recipe =
-            GeneratedRecipe::from_model(model.clone(), provider).into_diagnostic()?;
+        let mut generated_recipe = GeneratedRecipe::from_model(
+            model.clone(),
+            provider.map(|p| Box::new(p) as Box<dyn MetadataProvider>),
+        )
+        .into_diagnostic()?;
 
         // we need to add compilers
         let compiler_function = compiler_requirement(&Language::Rust);

--- a/crates/recipe-stage0/src/recipe.rs
+++ b/crates/recipe-stage0/src/recipe.rs
@@ -297,7 +297,7 @@ impl<T: Debug> Debug for Conditional<T> {
 pub type ConditionalList<T> = Vec<Item<T>>;
 
 // Main recipe structure
-#[derive(Serialize, Deserialize, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct IntermediateRecipe {
     #[serde(default)]
     pub context: IndexMap<String, Value<String>>,
@@ -575,12 +575,12 @@ pub(crate) struct Requirements {
     pub run_constraints: Vec<SerializableMatchSpec>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Test {
     pub package_contents: Option<PackageContents>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PackageContents {
     pub include: Option<ConditionalList<String>>,
     pub files: Option<ConditionalList<String>>,
@@ -597,7 +597,7 @@ pub struct About {
     pub repository: Option<Value<String>>,
 }
 
-#[derive(Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct Extra {
     #[serde(rename = "recipe-maintainers")]
     pub recipe_maintainers: ConditionalList<String>,


### PR DESCRIPTION
This uses the `cargo_toml` crate to read the manifest, and translates that to `name` `version` and the `about` section.

# TODO:
- [ ] Make `package` optional for all backends
