### PR TITLE
docs: direct to conda-forge instead of `pixi-build-backends`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,7 @@ For example, this `build-section` will use the python backend to build a python 
 build-backend = { name = "pixi-build-python", version = "*" }
 # These are the conda channels that are used to resolve the dependencies of the
 # build backend package.
-channels = [
-  "https://prefix.dev/pixi-build-backends",
-  "https://prefix.dev/conda-forge",
-]
+channels = ["https://prefix.dev/conda-forge"]
 ```
 
 

--- a/docs/backends/pixi-build-cmake.md
+++ b/docs/backends/pixi-build-cmake.md
@@ -33,7 +33,6 @@ version = "0.1.0"
 [package.build]
 backend = { name = "pixi-build-cmake", version = "*" }
 channels = [
-  "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",
 ]
 ```

--- a/docs/backends/pixi-build-mojo.md
+++ b/docs/backends/pixi-build-mojo.md
@@ -64,10 +64,9 @@ authors = ["J. Doe <jdoe@mail.com>"]
 platforms = ["linux-64"]
 preview = ["pixi-build"]
 channels = [
-    "conda-forge",
+    "https://prefix.dev/conda-forge",
     "https://conda.modular.com/max-nightly",
-    "https://prefix.dev/pixi-build-backends",
-    "https://repo.prefix.dev/modular-community"
+    "https://prefix.dev/modular-community"
 ]
 
 [package]

--- a/docs/backends/pixi-build-python.md
+++ b/docs/backends/pixi-build-python.md
@@ -31,10 +31,8 @@ version = "0.1.0"
 
 [package.build]
 backend = { name = "pixi-build-python", version = "*" }
-channels = [
-  "https://prefix.dev/pixi-build-backends",
-  "https://prefix.dev/conda-forge",
-]
+channels = ["https://prefix.dev/conda-forge"]
+
 ```
 
 ### Required Dependencies

--- a/docs/backends/pixi-build-rattler-build.md
+++ b/docs/backends/pixi-build-rattler-build.md
@@ -33,10 +33,7 @@ version = "0.1.0"
 
 [package.build]
 backend = { name = "pixi-build-rattler-build", version = "*" }
-channels = [
-  "https://prefix.dev/pixi-build-backends",
-  "https://prefix.dev/conda-forge",
-]
+channels = ["https://prefix.dev/conda-forge"]
 ```
 
 The backend expects a rattler-build recipe file in one of these locations (searched in order):

--- a/docs/backends/pixi-build-rust.md
+++ b/docs/backends/pixi-build-rust.md
@@ -32,10 +32,8 @@ version = "0.1.0"
 
 [package.build]
 backend = { name = "pixi-build-rust", version = "*" }
-channels = [
-  "https://prefix.dev/pixi-build-backends",
-  "https://prefix.dev/conda-forge",
-]
+channels = ["https://prefix.dev/conda-forge"]
+
 ```
 
 ### Required Dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,8 @@ The repository currently provides four specialized build backends:
 | [**`pixi-build-rust`**](./backends/pixi-build-rust.md) |  Cargo-based Rust applications and libraries |
 | [**`pixi-build-mojo`**](./backends/pixi-build-mojo.md) |  Mojo applications and packages |
 
-All backends are available through the [prefix.dev/pixi-build-backends](https://prefix.dev/channels/pixi-build-backends) conda channel and work across multiple platforms (Linux, macOS, Windows).
+All backends are available through the [prefix.dev/conda-forge](https://prefix.dev/channels/conda-forge) conda channel and work across multiple platforms (Linux, macOS, Windows).
+For the latest backend versions, you can extend the channel list with the [prefix.dev/pixi-build-backends](https://prefix.dev/channels/pixi-build-backends) conda channel, here we push the latest versions of the backends.
 
 ## 🛠️ Getting Started
 


### PR DESCRIPTION
Pointing users to use `conda-forge` first.