### PR TITLE
fix: preserve working directory for incremental compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1134,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1146,18 +1146,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.54"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
+checksum = "67e4efcbb5da11a92e8a609233aa1e8a7d91e38de0be865f016d14700d45a7fd"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_complete_nushell"
-version = "4.5.7"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb8335b398d197fb3176efe9400c6c053a41733c26794316c73423d212b2f3d"
+checksum = "0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2483,7 +2483,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2563,7 +2563,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2583,7 +2583,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -2829,6 +2829,17 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]
@@ -3171,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "lzma-rust2"
-version = "0.4.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecaa2bc9f1bd284be221d0770bbc9b92a438fdf422ba45211f6c6bf157ebb932"
+checksum = "26175dd096dfaab9f4fbf577a668842ebc48374d4d06b154bffb49918e242261"
 
 [[package]]
 name = "lzma-sys"
@@ -3224,9 +3235,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -3288,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.10.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd72e8b4e42274540edabec853f607c015c73436159b06c39c7af85a20433155"
+checksum = "4e60ac08614cc09062820e51d5d94c2fce16b94ea4e5003bb81b99a95f84e876"
 dependencies = [
  "aho-corasick",
  "serde",
@@ -3536,6 +3547,34 @@ checksum = "f947c4efbca344c1a125753366033c8107f552b2e3f8251815ed1908f116ca3e"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "quick-xml 0.37.5",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "opendal"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb9838d0575c6dbaf3fcec7255af8d5771996d4af900bbb6fa9a314dec00a1a"
+dependencies = [
+ "anyhow",
  "backon",
  "base64 0.22.1",
  "bytes",
@@ -4477,7 +4516,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.26",
- "socket2",
+ "socket2 0.5.9",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4513,7 +4552,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.9",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4654,8 +4693,8 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.44.0"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#8c42c38cfd0fc5a75e8fdba0c8cbe6d87831f912"
+version = "0.45.0"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#91f3dd7a9a45a367d68b1d5476c228275c4d1880"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4668,7 +4707,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "comfy-table",
- "console 0.15.11",
+ "console 0.16.0",
  "content_inspector",
  "diffy",
  "dunce",
@@ -4691,7 +4730,7 @@ dependencies = [
  "miette",
  "minijinja",
  "num_cpus",
- "opendal",
+ "opendal 0.54.0",
  "pathdiff",
  "petgraph 0.8.2",
  "rattler",
@@ -4742,7 +4781,7 @@ dependencies = [
  "walkdir",
  "which",
  "xz2",
- "zip 4.2.0",
+ "zip 4.3.0",
  "zstd",
 ]
 
@@ -4871,7 +4910,7 @@ dependencies = [
  "futures",
  "fxhash",
  "indicatif",
- "opendal",
+ "opendal 0.53.3",
  "rattler_conda_types",
  "rattler_digest",
  "rattler_networking",
@@ -5072,9 +5111,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_sandbox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815cae23697b8354a97760ffbf1aae9348ad3c357b70e1b871cfc67510632f8f"
+checksum = "bb8fabaf100a9cfab4d8b5e42bbf690596d225eb840f1c8552192a10e6c90ee7"
 dependencies = [
  "birdcage",
  "clap",
@@ -5935,9 +5974,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -6034,9 +6073,9 @@ dependencies = [
 
 [[package]]
 name = "sevenz-rust2"
-version = "0.16.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c12bd2c6a1f413f516836e80c1f541116f9b17ccbab2540f655ceeb58f5592c"
+checksum = "98644326f9145490e4c194dd775a9a2ed7e84f8254415eb709a7924f52fcd7a1"
 dependencies = [
  "aes",
  "byteorder",
@@ -6215,10 +6254,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "spdx"
-version = "0.10.8"
+name = "socket2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b69356da67e2fc1f542c71ea7e654a361a79c938e4424392ecf4fa065d2193"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "spdx"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
 dependencies = [
  "smallvec",
 ]
@@ -6562,20 +6611,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8085,9 +8136,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
+checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/crates/pixi-build-backend/src/intermediate_backend.rs
+++ b/crates/pixi-build-backend/src/intermediate_backend.rs
@@ -26,7 +26,7 @@ use pixi_build_types::{
     },
 };
 use rattler_build::{
-    build::run_build,
+    build::{WorkingDirectoryBehavior, run_build},
     console_utils::LoggingOutputHandler,
     hash::HashInfo,
     metadata::{
@@ -47,8 +47,9 @@ use rattler_build::{
     tool_configuration::Configuration,
     variant_config::{DiscoveredOutput, ParseErrors, VariantConfig},
 };
-use rattler_conda_types::compression_level::CompressionLevel;
-use rattler_conda_types::{ChannelConfig, MatchSpec, Platform, package::ArchiveType};
+use rattler_conda_types::{
+    ChannelConfig, MatchSpec, Platform, compression_level::CompressionLevel, package::ArchiveType,
+};
 use recipe_stage0::matchspec::{PackageDependency, SerializableMatchSpec};
 use serde::Deserialize;
 
@@ -791,7 +792,9 @@ where
             let temp_recipe = TemporaryRenderedRecipe::from_output(&output)?;
             let tool_config = tool_config.clone();
             let (output, package) = temp_recipe
-                .within_context_async(move || async move { run_build(output, &tool_config).await })
+                .within_context_async(move || async move {
+                    run_build(output, &tool_config, WorkingDirectoryBehavior::Preserve).await
+                })
                 .await?;
 
             // Extract the input globs from the build and recipe
@@ -1213,7 +1216,8 @@ where
             extra_meta: None,
         };
 
-        let (output, output_path) = run_build(output, &tool_config).await?;
+        let (output, output_path) =
+            run_build(output, &tool_config, WorkingDirectoryBehavior::Preserve).await?;
 
         // Extract the input globs from the build and recipe
         let mut input_globs = T::extract_input_globs_from_build(

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -32,7 +32,7 @@ use pixi_build_types::{
     },
 };
 use rattler_build::{
-    build::run_build,
+    build::{WorkingDirectoryBehavior, run_build},
     console_utils::LoggingOutputHandler,
     hash::HashInfo,
     metadata::{
@@ -577,7 +577,12 @@ impl Protocol for RattlerBuildBackend {
 
             let (output, build_path) = temp_recipe
                 .within_context_async(move || async move {
-                    run_build(output_with_build_string, tool_config).await
+                    run_build(
+                        output_with_build_string,
+                        tool_config,
+                        WorkingDirectoryBehavior::Preserve,
+                    )
+                    .await
                 })
                 .await?;
 
@@ -722,7 +727,8 @@ impl Protocol for RattlerBuildBackend {
             extra_meta: None,
         };
 
-        let (output, output_path) = run_build(output, &tool_config).await?;
+        let (output, output_path) =
+            run_build(output, &tool_config, WorkingDirectoryBehavior::Preserve).await?;
 
         Ok(CondaBuildV1Result {
             output_file: output_path,

--- a/py-pixi-build-backend/Cargo.lock
+++ b/py-pixi-build-backend/Cargo.lock
@@ -1121,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1142,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3208,9 +3208,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.4.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecaa2bc9f1bd284be221d0770bbc9b92a438fdf422ba45211f6c6bf157ebb932"
+checksum = "26175dd096dfaab9f4fbf577a668842ebc48374d4d06b154bffb49918e242261"
 
 [[package]]
 name = "lzma-sys"
@@ -3584,6 +3584,34 @@ checksum = "f947c4efbca344c1a125753366033c8107f552b2e3f8251815ed1908f116ca3e"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "quick-xml 0.37.5",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "opendal"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb9838d0575c6dbaf3fcec7255af8d5771996d4af900bbb6fa9a314dec00a1a"
+dependencies = [
+ "anyhow",
  "backon",
  "base64 0.22.1",
  "bytes",
@@ -4805,8 +4833,8 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.44.0"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#8c42c38cfd0fc5a75e8fdba0c8cbe6d87831f912"
+version = "0.45.0"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#91f3dd7a9a45a367d68b1d5476c228275c4d1880"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4819,7 +4847,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "comfy-table",
- "console 0.15.11",
+ "console 0.16.0",
  "content_inspector",
  "diffy",
  "dunce",
@@ -4842,7 +4870,7 @@ dependencies = [
  "miette",
  "minijinja",
  "num_cpus",
- "opendal",
+ "opendal 0.54.0",
  "pathdiff",
  "petgraph 0.8.2",
  "rattler 0.34.11",
@@ -5125,7 +5153,7 @@ dependencies = [
  "futures",
  "fxhash",
  "indicatif 0.17.11",
- "opendal",
+ "opendal 0.53.3",
  "rattler_conda_types 0.35.6",
  "rattler_config 0.2.3",
  "rattler_digest 1.1.4",
@@ -5160,7 +5188,7 @@ dependencies = [
  "futures",
  "fxhash",
  "indicatif 0.18.0",
- "opendal",
+ "opendal 0.53.3",
  "rattler_conda_types 0.37.0",
  "rattler_digest 1.1.5",
  "rattler_networking 0.25.8",
@@ -6435,9 +6463,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -6534,9 +6562,9 @@ dependencies = [
 
 [[package]]
 name = "sevenz-rust2"
-version = "0.16.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c12bd2c6a1f413f516836e80c1f541116f9b17ccbab2540f655ceeb58f5592c"
+checksum = "98644326f9145490e4c194dd775a9a2ed7e84f8254415eb709a7924f52fcd7a1"
 dependencies = [
  "aes",
  "byteorder",
@@ -7092,9 +7120,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
Bumps rattler-build to get https://github.com/prefix-dev/rattler-build/pull/1813 in. This will ensure that incremental compilation works! 