### PR TITLE
fix: cleanup working directory for rattler-build backend

### DIFF
--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -580,7 +580,7 @@ impl Protocol for RattlerBuildBackend {
                     run_build(
                         output_with_build_string,
                         tool_config,
-                        WorkingDirectoryBehavior::Preserve,
+                        WorkingDirectoryBehavior::Cleanup,
                     )
                     .await
                 })
@@ -728,7 +728,7 @@ impl Protocol for RattlerBuildBackend {
         };
 
         let (output, output_path) =
-            run_build(output, &tool_config, WorkingDirectoryBehavior::Preserve).await?;
+            run_build(output, &tool_config, WorkingDirectoryBehavior::Cleanup).await?;
 
         Ok(CondaBuildV1Result {
             output_file: output_path,


### PR DESCRIPTION
Fixes #287 

After some discussion, we decided to remove the working directory on each build invocation for rattler-build recipes.