### PR TITLE
chore: move recipes to folders

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -68,7 +68,7 @@ jobs:
           RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: "true"
           RATTLER_BUILD_COLOR: "always"
         run: |
-          pixi run build-recipe-ci $RUNNER_TEMP recipe/${{ matrix.bins.bin }}.yaml ${{ matrix.bins.target }}
+          pixi run build-recipe-ci $RUNNER_TEMP recipe/${{ matrix.bins.bin }}/recipe.yaml ${{ matrix.bins.target }}
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/recipe/pixi-build-api-version/recipe.yaml
+++ b/recipe/pixi-build-api-version/recipe.yaml
@@ -8,7 +8,9 @@ package:
   version: ${{ version }}
 
 source:
-  path: ..
+  path: ../..
+  filter:
+    - LICENSE
 
 build:
   noarch: generic
@@ -21,6 +23,5 @@ about:
   license: BSD-3-Clause
   license_file:
     - LICENSE
-    - THIRDPARTY.yml
   documentation: https://prefix-dev.github.io/pixi-build-backends
   repository: https://github.com/prefix-dev/pixi-build-backends

--- a/recipe/pixi-build-cmake/recipe.yaml
+++ b/recipe/pixi-build-cmake/recipe.yaml
@@ -8,7 +8,7 @@ package:
   version: ${{ version }}
 
 source:
-  path: ..
+  path: ../..
 
 build:
   script:

--- a/recipe/pixi-build-mojo/recipe.yaml
+++ b/recipe/pixi-build-mojo/recipe.yaml
@@ -1,14 +1,14 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 context:
-  name: pixi-build-rust
-  version: "${{ env.get('PIXI_BUILD_RUST_VERSION', default='0.1.0dev') }}"
+  name: pixi-build-mojo
+  version: "${{ env.get('PIXI_BUILD_MOJO_VERSION', default='0.1.0dev') }}"
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 source:
-  path: ..
+  path: ../..
 
 build:
   script:
@@ -53,9 +53,9 @@ tests:
 
 about:
   homepage: https://github.com/prefix-dev/pixi-build-backends
-  summary: A pixi build backend to build Rust packages.
+  summary: A pixi build backend to build Mojo packages.
   description: |
-    This package provides a build backend for pixi that allows building Rust packages.
+    This package provides a build backend for pixi that allows building packages using Mojo.
   license: BSD-3-Clause
   license_file:
     - LICENSE

--- a/recipe/pixi-build-py-pixi-build-backend/recipe.yaml
+++ b/recipe/pixi-build-py-pixi-build-backend/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "${{ env.get('PY_PIXI_BUILD_BACKEND', default='0.1.0dev') }}"
 
 source:
-  path: ..
+  path: ../..
 
 requirements:
   build:

--- a/recipe/pixi-build-python/recipe.yaml
+++ b/recipe/pixi-build-python/recipe.yaml
@@ -1,14 +1,14 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 context:
-  name: pixi-build-mojo
-  version: "${{ env.get('PIXI_BUILD_MOJO_VERSION', default='0.1.0dev') }}"
+  name: pixi-build-python
+  version: "${{ env.get('PIXI_BUILD_PYTHON_VERSION', default='0.1.0dev') }}"
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 source:
-  path: ..
+  path: ../..
 
 build:
   script:
@@ -53,9 +53,9 @@ tests:
 
 about:
   homepage: https://github.com/prefix-dev/pixi-build-backends
-  summary: A pixi build backend to build Mojo packages.
+  summary: A pixi build backend to build Python packages.
   description: |
-    This package provides a build backend for pixi that allows building packages using Mojo.
+    This package provides a build backend for pixi that allows building Python packages.
   license: BSD-3-Clause
   license_file:
     - LICENSE

--- a/recipe/pixi-build-rattler-build/recipe.yaml
+++ b/recipe/pixi-build-rattler-build/recipe.yaml
@@ -8,7 +8,7 @@ package:
   version: ${{ version }}
 
 source:
-  path: ..
+  path: ../..
 
 build:
   script:

--- a/recipe/pixi-build-rust/recipe.yaml
+++ b/recipe/pixi-build-rust/recipe.yaml
@@ -1,14 +1,14 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 context:
-  name: pixi-build-python
-  version: "${{ env.get('PIXI_BUILD_PYTHON_VERSION', default='0.1.0dev') }}"
+  name: pixi-build-rust
+  version: "${{ env.get('PIXI_BUILD_RUST_VERSION', default='0.1.0dev') }}"
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 source:
-  path: ..
+  path: ../..
 
 build:
   script:
@@ -53,9 +53,9 @@ tests:
 
 about:
   homepage: https://github.com/prefix-dev/pixi-build-backends
-  summary: A pixi build backend to build Python packages.
+  summary: A pixi build backend to build Rust packages.
   description: |
-    This package provides a build backend for pixi that allows building Python packages.
+    This package provides a build backend for pixi that allows building Rust packages.
   license: BSD-3-Clause
   license_file:
     - LICENSE


### PR DESCRIPTION
Move all recipes into folders, this the uses the default conventions of a "forge" which is easier to invoke with rattler-build.