### PR TITLE
feat: improve release workflow with manual builds and auto-versioning

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -101,7 +101,7 @@ jobs:
   upload:
     needs: aggregate
     runs-on: ubuntu-latest
-    if: ${{ (startsWith(github.ref, 'refs/tags') || (github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_channel == 'true')) && github.repository == 'prefix-dev/pixi-build-backends' }}
+    if: ${{ (startsWith(github.ref, 'refs/tags') || github.event.inputs.push_to_channel == 'true') && github.repository == 'prefix-dev/pixi-build-backends' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Download all conda packages


### PR DESCRIPTION
## Summary
- Remove automatic builds on main branch pushes to save CI minutes
- Add workflow_dispatch with "push to channel" option for manual builds
- Implement auto-versioning for main branch builds (version.ddmmyyyy.git_hash)
- Maintain backward compatibility with tag-based releases

## Test plan
- [x] Local testing of generate-matrix script 
- [x] Manual workflow dispatch test in GitHub Actions: https://github.com/prefix-dev/pixi-build-backends/actions/runs/16931505537/job/47977939062

🤖 Generated with [Claude Code](https://claude.ai/code)