### PR TITLE
fix: dev drive script

### DIFF
--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -12,7 +12,7 @@ if (Test-Path "D:\") {
 } else {
 	# The size (20 GB) is chosen empirically to be large enough for our
 	# workflows; larger drives can take longer to set up.
-	$Volume = New-VHD -Path C:/pixi_dev_drive.vhdx -SizeBytes 20GB |
+	$Volume = New-VHD -Path C:\pixi_dev_drive.vhdx -SizeBytes 20GB |
 						Mount-VHD -Passthru |
 						Initialize-Disk -Passthru |
 						New-Partition -AssignDriveLetter -UseMaximumSize |
@@ -29,8 +29,8 @@ if (Test-Path "D:\") {
 	fsutil devdrv enable /disallowAv
 
 	# Remount so the changes take effect
-	Dismount-VHD -Path C:/pixi_dev_drive.vhdx
-	Mount-VHD -Path C:/pixi_dev_drive.vhdx
+	Dismount-VHD -Path C:\pixi_dev_drive.vhdx
+	Mount-VHD -Path C:\pixi_dev_drive.vhdx
 
 	# Show some debug information
 	Write-Output $Volume
@@ -39,24 +39,24 @@ if (Test-Path "D:\") {
     Write-Output "Using Dev Drive at $Volume"
 }
 
-$Tmp = "$($Drive)/pixi-tmp"
+$Tmp = "$($Drive)\pixi-tmp"
 
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
 
 # Move Cargo to the dev drive
-New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
-if (Test-Path "C:/Users/runneradmin/.cargo") {
-    Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
+New-Item -Path "$($Drive)\.cargo\bin" -ItemType Directory -Force
+if (Test-Path "C:\Users\runneradmin\.cargo") {
+    Copy-Item -Path "C:\Users\runneradmin\.cargo\*" -Destination "$($Drive)\.cargo\" -Recurse -Force
 }
 
 Write-Output `
 	"DEV_DRIVE=$($Drive)" `
 	"TMP=$($Tmp)" `
 	"TEMP=$($Tmp)" `
-	"RATTLER_CACHE_DIR=$($Drive)/rattler-cache" `
-	"RUSTUP_HOME=$($Drive)/.rustup" `
-	"CARGO_HOME=$($Drive)/.cargo" `
-	"PIXI_HOME=$($Drive)/.pixi" `
-	"PIXI_WORKSPACE=$($Drive)/pixi" `
+	"RATTLER_CACHE_DIR=$($Drive)\rattler-cache" `
+	"RUSTUP_HOME=$($Drive)\.rustup" `
+	"CARGO_HOME=$($Drive)\.cargo" `
+	"PIXI_HOME=$($Drive)\.pixi" `
+	"PIXI_WORKSPACE=$($Drive)\pixi" `
 	>> $env:GITHUB_ENV


### PR DESCRIPTION
rattler-build isn't happy with mixed path separators
