### PR TITLE
fix: remove c compiler from recipe

### DIFF
--- a/recipe/py-pixi-build-backend/recipe.yaml
+++ b/recipe/py-pixi-build-backend/recipe.yaml
@@ -17,7 +17,6 @@ requirements:
         - python
         - cross-python_${{ target_platform }}
         - maturin >=1.2.2,<2
-    - ${{ compiler('c') }}
     - ${{ compiler('rust') }}
   host:
     - python


### PR DESCRIPTION
The C compiler resulting in the wrong Rust compiler being used on Windows.

https://github.com/prefix-dev/pixi-build-backends/actions/runs/16940331357/job/48007517688