### PR TITLE
fix: derive recipe dir from recipe path

### DIFF
--- a/crates/pixi-build-backend/src/intermediate_backend.rs
+++ b/crates/pixi-build-backend/src/intermediate_backend.rs
@@ -1134,7 +1134,6 @@ where
             params.build_prefix.as_ref().map(|p| p.prefix.as_path()),
             params.work_directory.clone(),
             self.cache_dir.as_deref(),
-            self.source_dir.clone(),
             params.output_directory.as_deref(),
             recipe_path,
         );
@@ -1280,12 +1279,14 @@ pub fn conda_build_v1_directories(
     build_prefix: Option<&Path>,
     work_directory: PathBuf,
     cache_dir: Option<&Path>,
-    source_dir: PathBuf,
     output_dir: Option<&Path>,
     recipe_path: PathBuf,
 ) -> Directories {
     Directories {
-        recipe_dir: source_dir,
+        recipe_dir: recipe_path
+            .parent()
+            .expect("recipe path must have a parent")
+            .to_path_buf(),
         recipe_path,
         cache_dir: cache_dir
             .map(Path::to_path_buf)

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -659,7 +659,6 @@ impl Protocol for RattlerBuildBackend {
             params.build_prefix.as_ref().map(|p| p.prefix.as_path()),
             params.work_directory,
             self.cache_dir.as_deref(),
-            self.source_dir.clone(),
             params.output_directory.as_deref(),
             self.recipe_source.path.clone(),
         );


### PR DESCRIPTION
We didnt pass the proper directory as recipe_dir to rattler_build which caused it to not properly resolve relative paths used in the `source` section.