### PR TITLE
fix: allow spaces within paths in build script

### DIFF
--- a/crates/pixi-build-python/src/build_script.j2
+++ b/crates/pixi-build-python/src/build_script.j2
@@ -3,9 +3,9 @@
 {% set COMMON_OPTIONS = "-vv --no-deps --no-build-isolation" + EDITABLE_OPTION -%}
 
 {% if installer == "uv" -%}
-uv pip install --python {{ PYTHON }} {{ COMMON_OPTIONS }} {{ manifest_root }}
+uv pip install --python {{ PYTHON }} {{ COMMON_OPTIONS }} "{{ manifest_root }}"
 {% else %}
-{{ PYTHON }} -m pip install --ignore-installed {{ COMMON_OPTIONS }} {{ manifest_root }}
+{{ PYTHON }} -m pip install --ignore-installed {{ COMMON_OPTIONS }} "{{ manifest_root }}"
 {% endif -%}
 
 {% if build_platform == "windows" -%}

--- a/crates/pixi-build-python/src/build_script.j2
+++ b/crates/pixi-build-python/src/build_script.j2
@@ -3,9 +3,9 @@
 {% set COMMON_OPTIONS = "-vv --no-deps --no-build-isolation" + EDITABLE_OPTION -%}
 
 {% if installer == "uv" -%}
-uv pip install --python {{ PYTHON }} {{ COMMON_OPTIONS }} "{{ manifest_root }}"
+uv pip install --python "{{ PYTHON }}" {{ COMMON_OPTIONS }} "{{ manifest_root }}"
 {% else %}
-{{ PYTHON }} -m pip install --ignore-installed {{ COMMON_OPTIONS }} "{{ manifest_root }}"
+"{{ PYTHON }}" -m pip install --ignore-installed {{ COMMON_OPTIONS }} "{{ manifest_root }}"
 {% endif -%}
 
 {% if build_platform == "windows" -%}

--- a/py-pixi-build-backend/examples/pixi-build-python/pixi_build_python/build_script.py
+++ b/py-pixi-build-backend/examples/pixi-build-python/pixi_build_python/build_script.py
@@ -66,9 +66,9 @@ class BuildScriptContext:
         common_options = f"-vv --no-deps --no-build-isolation{editable_option}"
 
         if self.installer == Installer.UV:
-            command = f"uv pip install --python {python_var} {common_options} {src_dir}"
+            command = f'uv pip install --python {python_var} {common_options} "{src_dir}"'
         else:
-            command = f"{python_var} -m pip install --ignore-installed {common_options} {src_dir}"
+            command = f'{python_var} -m pip install --ignore-installed {common_options} "{src_dir}"'
 
         lines = [command]
 

--- a/py-pixi-build-backend/examples/pixi-build-python/pixi_build_python/build_script.py
+++ b/py-pixi-build-backend/examples/pixi-build-python/pixi_build_python/build_script.py
@@ -66,9 +66,9 @@ class BuildScriptContext:
         common_options = f"-vv --no-deps --no-build-isolation{editable_option}"
 
         if self.installer == Installer.UV:
-            command = f'uv pip install --python {python_var} {common_options} "{src_dir}"'
+            command = f'uv pip install --python "{python_var}" {common_options} "{src_dir}"'
         else:
-            command = f'{python_var} -m pip install --ignore-installed {common_options} "{src_dir}"'
+            command = f'"{python_var}" -m pip install --ignore-installed {common_options} "{src_dir}"'
 
         lines = [command]
 


### PR DESCRIPTION
Hi,

When I try to build a pixi package with pixi-build-python, the build script fail because my project's path contains spaces. Currently the generated conda_build.sh script does not quote the the path when running installation with uv, as shown in this example:
```sh
#!/bin/bash
## Start of bash preamble
if [ -z ${CONDA_BUILD+x} ]; then
    source "/Users/valfvo/Library/Mobile Documents/com~apple~CloudDocs/projects/<redacted>/.pixi/build/work/utils-9onpsMVFaTY/work/build_env.sh"
fi
## End of preamble

uv pip install --python $PYTHON -vv --no-deps --no-build-isolation --editable /Users/valfvo/Library/Mobile Documents/com~apple~CloudDocs/projects/<redacted>
```
This results in uv not finding python:
```
 | - Running build script
 │ │ DEBUG uv 0.8.12
 │ │ DEBUG Marking explicit source tree for reinstall: `$SRC_DIR/Documents/com~apple~CloudDocs/projects/<redacted>/.pixi/build/work/<redacted>-Q
 │ │ ZRx5ZYrqz8/host_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/bin/python`
 │ │ DEBUG Marking explicit source tree for reinstall: `$SRC_DIR/Documents/com~apple~CloudDocs/projects/<redacted>`
 │ │ DEBUG Marking explicit source tree for reinstall: `/Users/valfvo/Library/Mobile`
 │ │ DEBUG Checking for Python interpreter at path `/Users/valfvo/Library/Mobile`
 │ │ TRACE Error trace: No virtual environment or system Python installation found for path `/Users/valfvo/Library/Mobile`; run `uv venv` to create an environme
 │ │ nt
 │ │ error: No virtual environment or system Python installation found for path `/Users/valfvo/Library/Mobile`; run `uv venv` to create an environment
 │ │ × error Script failed with status 2
 │ │ × error 
 │ │ × error Script execution failed.
 │ │ × error 
 │ │ × error   Work directory: /Users/valfvo/Library/Mobile Documents/com~apple~CloudDocs/projects/<redacted>.pixi/build/work/<redacted>-QZRx5ZY
 │ │ × error rqz8/work
 │ │ × error   Prefix: /Users/valfvo/Library/Mobile Documents/com~apple~CloudDocs/projects/<redacted>/.pixi/build/work/<redacted>-QZRx5ZYrqz8/hos
 │ │ × error t_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p
 │ │ × error   Build prefix: /Users/valfvo/Library/Mobile Documents/com~apple~CloudDocs/projects/<redacted>/.pixi/build/work/<redacted>-QZRx5ZYrq
 │ │ × error z8/bld
 │ │ × error 
 │ │ × error To run the script manually, use the following command:
 │ │ × error 
 │ │ × error   cd "/Users/valfvo/Library/Mobile Documents/com~apple~CloudDocs/projects/<redacted>/.pixi/build/work/<redacted>-QZRx5ZYrqz8/work" &
 │ │ × error & ./conda_build.sh
 │ │ × error 
 │ │ × error To run commands interactively in the build environment:
 │ │ × error 
 │ │ × error   cd "/Users/valfvo/Library/Mobile Documents/com~apple~CloudDocs/projects/<redacted>/.pixi/build/work/<redacted>-QZRx5ZYrqz8/work" &
 │ │ × error & source build_env.sh
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 ╰─────────────────── (took 1 second)
Error:   × failed to build 'utils' from '../utils'
  ╰─▶   × Script failed to execute
```
This PR tries to fix that by adding quotes around `$PYTHON` and `manifest_root`. I say try because i don't know if there are other files / build steps that use unquoted paths and may fail with paths with spaces.