### PR TITLE
chore: remove unnecessary &mut

### DIFF
--- a/crates/pixi-build-backend/src/generated_recipe.rs
+++ b/crates/pixi-build-backend/src/generated_recipe.rs
@@ -116,7 +116,7 @@ impl GeneratedRecipe {
     /// build scripts or other fields.
     pub fn from_model<M: MetadataProvider>(
         model: ProjectModelV1,
-        provider: &mut M,
+        provider: &M,
     ) -> Result<Self, GenerateRecipeError<M::Error>> {
         // If the name is not defined in the model, we try to get it from the provider.
         // If the provider cannot provide a name, we return an error.
@@ -212,35 +212,35 @@ pub trait MetadataProvider {
 
     /// Returns the name of the package or `None` if the provider does not
     /// provide a name.
-    fn name(&mut self) -> Result<Option<String>, Self::Error> {
+    fn name(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
     }
 
     /// Returns the version of the package or `None` if the provider does not
     /// provide a version.
-    fn version(&mut self) -> Result<Option<Version>, Self::Error> {
+    fn version(&self) -> Result<Option<Version>, Self::Error> {
         Ok(None)
     }
 
-    fn homepage(&mut self) -> Result<Option<String>, Self::Error> {
+    fn homepage(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
     }
-    fn license(&mut self) -> Result<Option<String>, Self::Error> {
+    fn license(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
     }
-    fn license_file(&mut self) -> Result<Option<String>, Self::Error> {
+    fn license_file(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
     }
-    fn summary(&mut self) -> Result<Option<String>, Self::Error> {
+    fn summary(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
     }
-    fn description(&mut self) -> Result<Option<String>, Self::Error> {
+    fn description(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
     }
-    fn documentation(&mut self) -> Result<Option<String>, Self::Error> {
+    fn documentation(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
     }
-    fn repository(&mut self) -> Result<Option<String>, Self::Error> {
+    fn repository(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
     }
 }

--- a/crates/pixi-build-backend/tests/integration/protocol.rs
+++ b/crates/pixi-build-backend/tests/integration/protocol.rs
@@ -64,8 +64,7 @@ mod imp {
             _python_params: Option<PythonParams>,
             _variants: &HashSet<pixi_build_backend::variants::NormalizedKey>,
         ) -> miette::Result<GeneratedRecipe> {
-            GeneratedRecipe::from_model(model.clone(), &mut DefaultMetadataProvider)
-                .into_diagnostic()
+            GeneratedRecipe::from_model(model.clone(), &DefaultMetadataProvider).into_diagnostic()
         }
     }
 }

--- a/crates/pixi-build-cmake/src/main.rs
+++ b/crates/pixi-build-cmake/src/main.rs
@@ -35,7 +35,7 @@ impl GenerateRecipe for CMakeGenerator {
         variants: &HashSet<NormalizedKey>,
     ) -> miette::Result<GeneratedRecipe> {
         let mut generated_recipe =
-            GeneratedRecipe::from_model(model.clone(), &mut DefaultMetadataProvider)
+            GeneratedRecipe::from_model(model.clone(), &DefaultMetadataProvider)
                 .into_diagnostic()?;
 
         // we need to add compilers

--- a/crates/pixi-build-mojo/src/main.rs
+++ b/crates/pixi-build-mojo/src/main.rs
@@ -36,7 +36,7 @@ impl GenerateRecipe for MojoGenerator {
         variants: &HashSet<NormalizedKey>,
     ) -> miette::Result<GeneratedRecipe> {
         let mut generated_recipe =
-            GeneratedRecipe::from_model(model.clone(), &mut DefaultMetadataProvider)
+            GeneratedRecipe::from_model(model.clone(), &DefaultMetadataProvider)
                 .into_diagnostic()?;
 
         let cleaned_project_name = clean_project_name(

--- a/crates/pixi-build-python/src/main.rs
+++ b/crates/pixi-build-python/src/main.rs
@@ -62,7 +62,7 @@ impl GenerateRecipe for PythonGenerator {
     ) -> miette::Result<GeneratedRecipe> {
         let params = python_params.unwrap_or_default();
 
-        let mut pyproject_metadata_provider = PyprojectMetadataProvider::new(
+        let pyproject_metadata_provider = PyprojectMetadataProvider::new(
             &manifest_root,
             config
                 .ignore_pyproject_manifest
@@ -70,7 +70,7 @@ impl GenerateRecipe for PythonGenerator {
         );
 
         let mut generated_recipe =
-            GeneratedRecipe::from_model(model.clone(), &mut pyproject_metadata_provider)
+            GeneratedRecipe::from_model(model.clone(), &pyproject_metadata_provider)
                 .into_diagnostic()?;
 
         let requirements = &mut generated_recipe.recipe.requirements;

--- a/crates/pixi-build-python/src/metadata.rs
+++ b/crates/pixi-build-python/src/metadata.rs
@@ -86,7 +86,7 @@ impl MetadataProvider for PyprojectMetadataProvider {
     ///
     /// If `ignore_pyproject_manifest` is true, returns `None`. Otherwise, extracts
     /// the name from the project section of the pyproject.toml file.
-    fn name(&mut self) -> Result<Option<String>, Self::Error> {
+    fn name(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_pyproject_manifest {
             return Ok(None);
         }
@@ -100,7 +100,7 @@ impl MetadataProvider for PyprojectMetadataProvider {
     /// If `ignore_pyproject_manifest` is true, returns `None`. Otherwise, extracts
     /// the version from the project section. The version string is parsed into a
     /// `rattler_conda_types::Version`.
-    fn version(&mut self) -> Result<Option<Version>, Self::Error> {
+    fn version(&self) -> Result<Option<Version>, Self::Error> {
         if self.ignore_pyproject_manifest {
             return Ok(None);
         }
@@ -119,7 +119,7 @@ impl MetadataProvider for PyprojectMetadataProvider {
     ///
     /// If `ignore_pyproject_manifest` is true, returns `None`. Otherwise, extracts
     /// the description from the project section.
-    fn description(&mut self) -> Result<Option<String>, Self::Error> {
+    fn description(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_pyproject_manifest {
             return Ok(None);
         }
@@ -132,7 +132,7 @@ impl MetadataProvider for PyprojectMetadataProvider {
     ///
     /// If `ignore_pyproject_manifest` is true, returns `None`. Otherwise, extracts
     /// the homepage from the project.urls section.
-    fn homepage(&mut self) -> Result<Option<String>, Self::Error> {
+    fn homepage(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_pyproject_manifest {
             return Ok(None);
         }
@@ -146,7 +146,7 @@ impl MetadataProvider for PyprojectMetadataProvider {
     ///
     /// If `ignore_pyproject_manifest` is true, returns `None`. Otherwise, extracts
     /// the license from the project section.
-    fn license(&mut self) -> Result<Option<String>, Self::Error> {
+    fn license(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_pyproject_manifest {
             return Ok(None);
         }
@@ -165,7 +165,7 @@ impl MetadataProvider for PyprojectMetadataProvider {
     /// If `ignore_pyproject_manifest` is true, returns `None`. Otherwise, extracts
     /// the license file path from the project section if the license is specified
     /// as a file reference.
-    fn license_file(&mut self) -> Result<Option<String>, Self::Error> {
+    fn license_file(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_pyproject_manifest {
             return Ok(None);
         }
@@ -183,7 +183,7 @@ impl MetadataProvider for PyprojectMetadataProvider {
     ///
     /// This returns the same as description since pyproject.toml doesn't have
     /// a separate summary field.
-    fn summary(&mut self) -> Result<Option<String>, Self::Error> {
+    fn summary(&self) -> Result<Option<String>, Self::Error> {
         self.description()
     }
 
@@ -191,7 +191,7 @@ impl MetadataProvider for PyprojectMetadataProvider {
     ///
     /// If `ignore_pyproject_manifest` is true, returns `None`. Otherwise, extracts
     /// the documentation URL from the project.urls section.
-    fn documentation(&mut self) -> Result<Option<String>, Self::Error> {
+    fn documentation(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_pyproject_manifest {
             return Ok(None);
         }
@@ -209,7 +209,7 @@ impl MetadataProvider for PyprojectMetadataProvider {
     ///
     /// If `ignore_pyproject_manifest` is true, returns `None`. Otherwise, extracts
     /// the repository URL from the project.urls section.
-    fn repository(&mut self) -> Result<Option<String>, Self::Error> {
+    fn repository(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_pyproject_manifest {
             return Ok(None);
         }
@@ -268,7 +268,7 @@ Documentation = "https://docs.example.com"
 "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         assert_eq!(provider.name().unwrap(), Some("test-package".to_string()));
         assert_eq!(provider.version().unwrap().unwrap().to_string(), "1.0.0");
@@ -301,7 +301,7 @@ license = {file = "LICENSE.txt"}
 "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         assert_eq!(provider.license().unwrap(), Some("LICENSE.txt".to_string()));
         assert_eq!(
@@ -318,7 +318,7 @@ requires = ["setuptools", "wheel"]
 "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         assert_eq!(provider.name().unwrap(), None);
         assert_eq!(provider.version().unwrap(), None);
@@ -334,7 +334,7 @@ requires = ["setuptools", "wheel"]
     "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         // Force loading of manifest
         let _ = provider.name().unwrap();
@@ -354,7 +354,7 @@ description = "Test description"
 "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = PyprojectMetadataProvider::new(temp_dir.path(), true);
+        let provider = PyprojectMetadataProvider::new(temp_dir.path(), true);
 
         // All methods should return None when ignore_pyproject_manifest is true
         assert_eq!(provider.name().unwrap(), None);
@@ -381,7 +381,7 @@ Docs = "https://docs.example.com"
 "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         assert_eq!(
             provider.repository().unwrap(),
@@ -402,7 +402,7 @@ version = "1.0.0a1"
 "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         // This should parse successfully since it's a valid PEP440 version
         let result = provider.version();
@@ -419,7 +419,7 @@ version = "not.a.valid.version.at.all"
 "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.version();
         // The pyproject-toml parser should fail to parse this
@@ -443,7 +443,7 @@ version = "1.0.0"
 "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.name();
         assert!(result.is_err());
@@ -463,7 +463,7 @@ description = "Test description"
 "#;
 
         let temp_dir = create_temp_pyproject_project(pyproject_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let description = provider.description().unwrap();
         let summary = provider.summary().unwrap();

--- a/crates/pixi-build-rust/src/main.rs
+++ b/crates/pixi-build-rust/src/main.rs
@@ -43,14 +43,14 @@ impl GenerateRecipe for RustGenerator {
     ) -> miette::Result<GeneratedRecipe> {
         // Construct a CargoMetadataProvider to read the Cargo.toml file
         // and extract metadata from it.
-        let mut cargo_metadata = CargoMetadataProvider::new(
+        let cargo_metadata = CargoMetadataProvider::new(
             &manifest_root,
             config.ignore_cargo_manifest.is_some_and(|ignore| ignore),
         );
 
         // Create the recipe
         let mut generated_recipe =
-            GeneratedRecipe::from_model(model.clone(), &mut cargo_metadata).into_diagnostic()?;
+            GeneratedRecipe::from_model(model.clone(), &cargo_metadata).into_diagnostic()?;
 
         // we need to add compilers
         let requirements = &mut generated_recipe.recipe.requirements;

--- a/crates/pixi-build-rust/src/metadata.rs
+++ b/crates/pixi-build-rust/src/metadata.rs
@@ -131,7 +131,7 @@ impl MetadataProvider for CargoMetadataProvider {
     ///
     /// If `ignore_cargo_manifest` is true, returns `None`. Otherwise, extracts
     /// the name from the package section of the Cargo.toml file.
-    fn name(&mut self) -> Result<Option<String>, Self::Error> {
+    fn name(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_cargo_manifest {
             return Ok(None);
         }
@@ -144,7 +144,7 @@ impl MetadataProvider for CargoMetadataProvider {
     /// the version from the package section, handling workspace inheritance if
     /// needed. The version string is parsed into a
     /// `rattler_conda_types::Version`.
-    fn version(&mut self) -> Result<Option<Version>, Self::Error> {
+    fn version(&self) -> Result<Option<Version>, Self::Error> {
         if self.ignore_cargo_manifest {
             return Ok(None);
         }
@@ -170,7 +170,7 @@ impl MetadataProvider for CargoMetadataProvider {
     /// If `ignore_cargo_manifest` is true, returns `None`. Otherwise, extracts
     /// the description from the package section, handling workspace inheritance
     /// if needed.
-    fn description(&mut self) -> Result<Option<String>, Self::Error> {
+    fn description(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_cargo_manifest {
             return Ok(None);
         }
@@ -197,7 +197,7 @@ impl MetadataProvider for CargoMetadataProvider {
     /// If `ignore_cargo_manifest` is true, returns `None`. Otherwise, extracts
     /// the homepage from the package section, handling workspace inheritance if
     /// needed.
-    fn homepage(&mut self) -> Result<Option<String>, Self::Error> {
+    fn homepage(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_cargo_manifest {
             return Ok(None);
         }
@@ -224,7 +224,7 @@ impl MetadataProvider for CargoMetadataProvider {
     /// If `ignore_cargo_manifest` is true, returns `None`. Otherwise, extracts
     /// the license from the package section, handling workspace inheritance if
     /// needed.
-    fn license(&mut self) -> Result<Option<String>, Self::Error> {
+    fn license(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_cargo_manifest {
             return Ok(None);
         }
@@ -252,7 +252,7 @@ impl MetadataProvider for CargoMetadataProvider {
     /// the license-file from the package section, handling workspace
     /// inheritance if needed. The path is converted to a string
     /// representation.
-    fn license_file(&mut self) -> Result<Option<String>, Self::Error> {
+    fn license_file(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_cargo_manifest {
             return Ok(None);
         }
@@ -279,7 +279,7 @@ impl MetadataProvider for CargoMetadataProvider {
     /// Currently always returns `None` as Cargo.toml does not have a summary
     /// field. This could be implemented to return the description field as
     /// a fallback.
-    fn summary(&mut self) -> Result<Option<String>, Self::Error> {
+    fn summary(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
     }
 
@@ -288,7 +288,7 @@ impl MetadataProvider for CargoMetadataProvider {
     /// If `ignore_cargo_manifest` is true, returns `None`. Otherwise, extracts
     /// the documentation from the package section, handling workspace
     /// inheritance if needed.
-    fn documentation(&mut self) -> Result<Option<String>, Self::Error> {
+    fn documentation(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_cargo_manifest {
             return Ok(None);
         }
@@ -318,7 +318,7 @@ impl MetadataProvider for CargoMetadataProvider {
     /// If `ignore_cargo_manifest` is true, returns `None`. Otherwise, extracts
     /// the repository from the package section, handling workspace inheritance
     /// if needed.
-    fn repository(&mut self) -> Result<Option<String>, Self::Error> {
+    fn repository(&self) -> Result<Option<String>, Self::Error> {
         if self.ignore_cargo_manifest {
             return Ok(None);
         }
@@ -432,7 +432,7 @@ documentation.workspace = true
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         // Test that workspace inheritance works when workspace is in the same file
         assert_eq!(provider.name().unwrap(), Some("test-package".to_string()));
@@ -466,7 +466,7 @@ description = "Regular description"
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         // Test that inheritance fails when no workspace is defined
         let result = provider.version();
@@ -483,7 +483,7 @@ description.workspace = true
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.description();
         assert_missing_inherited_value_error(result, "workspace.package.description");
@@ -499,7 +499,7 @@ license.workspace = true
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.license();
         assert_missing_inherited_value_error(result, "workspace.package.license");
@@ -515,7 +515,7 @@ homepage.workspace = true
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.homepage();
         assert_missing_inherited_value_error(result, "workspace.package.homepage");
@@ -531,7 +531,7 @@ repository.workspace = true
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.repository();
         assert_missing_inherited_value_error(result, "workspace.package.repository");
@@ -547,7 +547,7 @@ documentation.workspace = true
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.documentation();
         assert_missing_inherited_value_error(result, "workspace.package.documentation");
@@ -563,7 +563,7 @@ license-file.workspace = true
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.license_file();
         assert_missing_inherited_value_error(result, "workspace.package.license-file");
@@ -587,7 +587,7 @@ license = "Apache-2.0"
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         // Test mixed inheritance and direct values
         assert_eq!(provider.version().unwrap().unwrap().to_string(), "2.0.0");
@@ -615,7 +615,7 @@ license.workspace = true
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         // Version should work
         assert_eq!(provider.version().unwrap().unwrap().to_string(), "1.5.0");
@@ -644,7 +644,7 @@ version.workspace = true
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         // Force loading of manifest and workspace
         let _ = provider.version().unwrap();
@@ -690,7 +690,7 @@ description.workspace = true
         fs::write(package_dir.join("Cargo.toml"), package_cargo_toml)
             .expect("Failed to write package Cargo.toml");
 
-        let mut provider = create_metadata_provider(&package_dir);
+        let provider = create_metadata_provider(&package_dir);
 
         // Force loading of manifest and workspace
         let version_result = provider.version();
@@ -729,7 +729,7 @@ version = "1.0.0"
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         // Force loading of manifest
         let _ = provider.version().unwrap();
@@ -770,7 +770,7 @@ description = "Direct package values"
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         // Force loading of manifest - no inheritance should occur
         let version = provider.version().unwrap().unwrap();
@@ -801,7 +801,7 @@ description = "Test description"
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = CargoMetadataProvider::new(temp_dir.path(), true);
+        let provider = CargoMetadataProvider::new(temp_dir.path(), true);
 
         // All methods should return None when ignore_cargo_manifest is true
         assert_eq!(provider.name().unwrap(), None);
@@ -824,7 +824,7 @@ version = "not.a.valid.version.at.all"
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.version();
         // Note: rattler_conda_types::Version is quite permissive, so let's test what actually happens
@@ -849,7 +849,7 @@ version = "1.0.0"
 "#;
 
         let temp_dir = create_temp_cargo_project(cargo_toml_content);
-        let mut provider = create_metadata_provider(temp_dir.path());
+        let provider = create_metadata_provider(temp_dir.path());
 
         let result = provider.name();
         assert!(result.is_err());

--- a/py-pixi-build-backend/src/types/generated_recipe.rs
+++ b/py-pixi-build-backend/src/types/generated_recipe.rs
@@ -48,7 +48,7 @@ impl PyGeneratedRecipe {
     #[staticmethod]
     pub fn from_model(py: Python, model: PyProjectModelV1) -> PyResult<Self> {
         let generated_recipe =
-            GeneratedRecipe::from_model(model.inner.clone(), &mut DefaultMetadataProvider)
+            GeneratedRecipe::from_model(model.inner.clone(), &DefaultMetadataProvider)
                 .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
 
         let py_recipe = Py::new(


### PR DESCRIPTION
I've noticed that we pass &mut MetaDataProvider everywhere, without any obvious reason. After removing it everything still compiles just fine