### PR TITLE
fix: `Cleanup` -> `Preserve` for non- rattler-build backends

### DIFF
--- a/crates/pixi-build-backend/src/intermediate_backend.rs
+++ b/crates/pixi-build-backend/src/intermediate_backend.rs
@@ -1198,9 +1198,7 @@ where
         };
 
         let (output, output_path) =
-            // WorkingDirectoryBehavior::Preserve is blocked by
-            // https://github.com/prefix-dev/rattler-build/issues/1825
-            run_build(output, &tool_config, WorkingDirectoryBehavior::Cleanup).await?;
+            run_build(output, &tool_config, WorkingDirectoryBehavior::Preserve).await?;
 
         // Extract the input globs from the build and recipe
         let mut input_globs = T::extract_input_globs_from_build(

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -578,9 +578,7 @@ impl Protocol for RattlerBuildBackend {
                     run_build(
                         output_with_build_string,
                         tool_config,
-                        // WorkingDirectoryBehavior::Preserve is blocked by
-                        // https://github.com/prefix-dev/rattler-build/issues/1825
-                        WorkingDirectoryBehavior::Cleanup,
+                        WorkingDirectoryBehavior::Preserve,
                     )
                     .await
                 })
@@ -718,9 +716,7 @@ impl Protocol for RattlerBuildBackend {
         };
 
         let (output, output_path) =
-            // WorkingDirectoryBehavior::Preserve is blocked by
-            // https://github.com/prefix-dev/rattler-build/issues/1825
-            run_build(output, &tool_config, WorkingDirectoryBehavior::Cleanup).await?;
+            run_build(output, &tool_config, WorkingDirectoryBehavior::Preserve).await?;
 
         Ok(CondaBuildV1Result {
             output_file: output_path,

--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -578,7 +578,8 @@ impl Protocol for RattlerBuildBackend {
                     run_build(
                         output_with_build_string,
                         tool_config,
-                        WorkingDirectoryBehavior::Preserve,
+                        // rattler-build requires a clean work dir
+                        WorkingDirectoryBehavior::Cleanup,
                     )
                     .await
                 })
@@ -716,7 +717,8 @@ impl Protocol for RattlerBuildBackend {
         };
 
         let (output, output_path) =
-            run_build(output, &tool_config, WorkingDirectoryBehavior::Preserve).await?;
+            // rattler-build requires a clean work dir
+            run_build(output, &tool_config, WorkingDirectoryBehavior::Cleanup).await?;
 
         Ok(CondaBuildV1Result {
             output_file: output_path,


### PR DESCRIPTION
closes gh-326