### PR TITLE
chore: update all versions and dependencies on the api version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-cmake"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "indexmap 2.11.0",
  "insta",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-mojo"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "indexmap 2.11.0",
  "insta",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-python"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "fs-err",
  "indexmap 2.11.0",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-rust"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "cargo_toml",
  "fs-err",

--- a/crates/pixi-build-cmake/Cargo.toml
+++ b/crates/pixi-build-cmake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi-build-cmake"
-version = "0.3.2"
+version = "0.3.3"
 description = "CMake build backend for Pixi"
 edition.workspace = true
 

--- a/crates/pixi-build-cmake/pixi.toml
+++ b/crates/pixi-build-cmake/pixi.toml
@@ -1,14 +1,10 @@
-[workspace]
-channels = ["https://prefix.dev/conda-forge"]
-preview = ["pixi-build"]
-
-[package]
-name = "pixi-build-cmake"
-version = "0.3.2"
-
-[package.build]
-backend = { name = "pixi-build-rust", version = "*" }
+[package.build.backend]
+name = "pixi-build-rust"
+version = "*"
 channels = [
   "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",
 ]
+
+[package.run-dependencies]
+pixi-build-api-version = ">=2,<3"

--- a/crates/pixi-build-mojo/Cargo.toml
+++ b/crates/pixi-build-mojo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi-build-mojo"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 
 [dependencies]

--- a/crates/pixi-build-mojo/pixi.toml
+++ b/crates/pixi-build-mojo/pixi.toml
@@ -1,14 +1,10 @@
-[workspace]
-channels = ["https://prefix.dev/conda-forge"]
-preview = ["pixi-build"]
-
-[package]
-name = "pixi-build-mojo"
-version = "0.1.2"
-
-[package.build]
-backend = { name = "pixi-build-rust", version = "*" }
+[package.build.backend]
+name = "pixi-build-rust"
+version = "*"
 channels = [
   "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",
 ]
+
+[package.run-dependencies]
+pixi-build-api-version = ">=2,<3"

--- a/crates/pixi-build-python/Cargo.toml
+++ b/crates/pixi-build-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi-build-python"
-version = "0.3.2"
+version = "0.4.0"
 edition.workspace = true
 
 [dependencies]

--- a/crates/pixi-build-python/pixi.toml
+++ b/crates/pixi-build-python/pixi.toml
@@ -1,14 +1,10 @@
-[workspace]
-channels = ["https://prefix.dev/conda-forge"]
-preview = ["pixi-build"]
-
-[package]
-name = "pixi-build-python"
-version = "0.3.2"
-
-[package.build]
-backend = { name = "pixi-build-rust", version = "*" }
+[package.build.backend]
+name = "pixi-build-rust"
+version = "*"
 channels = [
   "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",
 ]
+
+[package.run-dependencies]
+pixi-build-api-version = ">=2,<3"

--- a/crates/pixi-build-rattler-build/pixi.toml
+++ b/crates/pixi-build-rattler-build/pixi.toml
@@ -1,14 +1,10 @@
-[workspace]
-channels = ["https://prefix.dev/conda-forge"]
-preview = ["pixi-build"]
-
-[package]
-name = "pixi-build-rattler-build"
-version = "0.3.2"
-
-[package.build]
-backend = { name = "pixi-build-rust", version = "*" }
+[package.build.backend]
+name = "pixi-build-rust"
+version = "*"
 channels = [
   "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",
 ]
+
+[package.run-dependencies]
+pixi-build-api-version = ">=2,<3"

--- a/crates/pixi-build-rust/Cargo.toml
+++ b/crates/pixi-build-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi-build-rust"
-version = "0.3.2"
+version = "0.4.0"
 description = "A Rust build backend for Pixi"
 documentation = "https://prefix-dev.github.io/pixi-build-backends/backends/pixi-build-rust/"
 repository.workspace = true

--- a/crates/pixi-build-rust/pixi.toml
+++ b/crates/pixi-build-rust/pixi.toml
@@ -1,14 +1,10 @@
-[workspace]
-channels = ["https://prefix.dev/conda-forge"]
-preview = ["pixi-build"]
-
-[package]
+[package.build.backend]
 name = "pixi-build-rust"
-version = "0.3.2"
-
-[package.build]
-backend = { name = "pixi-build-rust", version = "*" }
+version = "*"
 channels = [
   "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",
 ]
+
+[package.run-dependencies]
+pixi-build-api-version = ">=2,<3"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,10 +1,11 @@
-[project]
+[workspace]
 name = "pixi-build"
 version = "0.1.0"
 description = "Binary for building pixi projects into packages"
 authors = ["Tim de Jager <tim@prefix.dev>"]
 channels = ["https://prefix.dev/conda-forge"]
 platforms = ["osx-arm64", "win-64", "linux-64", "osx-64"]
+preview = ["pixi-build"]
 
 [tasks]
 run = "cargo run"
@@ -118,6 +119,14 @@ pillow = ">=9.4.0"
 build-docs = "mkdocs build --strict"
 docs = { cmd = "mkdocs serve", description = "Serve the docs locally" }
 
+#[feature.dev.dependencies]
+#pixi-build-python = { path = "crates/pixi-build-python" }
+#pixi-build-cmake = { path = "crates/pixi-build-cmake" }
+#pixi-build-rattler-build = { path = "crates/pixi-build-rattler-build" }
+#pixi-build-rust = { path = "crates/pixi-build-rust" }
+#pixi-build-mojo = { path = "crates/pixi-build-mojo" }
+#pixi-build-ros = { path = "backends/pixi-build-ros" }
+#py-pixi-build-backend = { path = "crates/py-pixi-build-backend" }
 
 [environments]
 default = { solve-group = "default" }
@@ -125,3 +134,4 @@ lint = { features = ["lint"], solve-group = "default" }
 docs = { features = ["docs"], no-default-feature = true }
 schema = { features = ["schema"], no-default-feature = true }
 build = { features = ["build"], no-default-feature = true }
+#dev = { features = ["dev"], no-default-feature = true }

--- a/py-pixi-build-backend/Cargo.lock
+++ b/py-pixi-build-backend/Cargo.lock
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "py-pixi-build-backend"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dict_derive",
  "indexmap 2.11.0",

--- a/py-pixi-build-backend/Cargo.toml
+++ b/py-pixi-build-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-pixi-build-backend"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [lib]

--- a/py-pixi-build-backend/pixi.toml
+++ b/py-pixi-build-backend/pixi.toml
@@ -9,16 +9,11 @@ license = "BSD-3-Clause"
 preview = ["pixi-build"]
 
 [package]
-name = "py-pixi-build-backend"
 version = "0.1.2"
 
 [package.build.backend]
 name = "pixi-build-python"
 version = "*"
-channels = [
-  "https://prefix.dev/pixi-build-backends",
-  "https://prefix.dev/conda-forge",
-]
 
 [package.build.config]
 compilers = ["rust"]

--- a/recipe/pixi-build-cmake/recipe.yaml
+++ b/recipe/pixi-build-cmake/recipe.yaml
@@ -43,7 +43,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=0,<2
+    - pixi-build-api-version >=2,<3
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-mojo/recipe.yaml
+++ b/recipe/pixi-build-mojo/recipe.yaml
@@ -43,7 +43,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=0,<2
+    - pixi-build-api-version >=2,<3
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-python/recipe.yaml
+++ b/recipe/pixi-build-python/recipe.yaml
@@ -43,7 +43,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=0,<2
+    - pixi-build-api-version >=2,<3
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-rattler-build/recipe.yaml
+++ b/recipe/pixi-build-rattler-build/recipe.yaml
@@ -43,7 +43,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=0,<2
+    - pixi-build-api-version >=0,<3
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-ros/recipe.yaml
+++ b/recipe/pixi-build-ros/recipe.yaml
@@ -22,6 +22,7 @@ requirements:
     - pyyaml
     - typing-extensions
     - py-pixi-build-backend
+    - pixi-build-api-version >=2,<3
 
 build:
   script:

--- a/recipe/pixi-build-rust/recipe.yaml
+++ b/recipe/pixi-build-rust/recipe.yaml
@@ -43,7 +43,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=0,<2
+    - pixi-build-api-version >=2,<3
 
 tests:
   - script: ${{ name }} --help


### PR DESCRIPTION
This PR bumps all the versions because `name` is now optional.

I've updated the `minor` version if that means that you can actually skip the `name` and `version` in the backend. e.g. `rust` and `python. For the rest I did a patch as it's just a refactor that shouldn't change the usage as they don't provide names through other tools. 