### PR TITLE
fix: use year-month-date instead of date-month-year

### DIFF
--- a/scripts/generate-matrix.py
+++ b/scripts/generate-matrix.py
@@ -32,7 +32,7 @@ def get_git_short_hash():
 
 
 def get_current_date():
-    """Get current date in ddmmyyyy format"""
+    """Get current date in yyyymmdd format"""
     return datetime.now().strftime("%Y%m%d")
 
 


### PR DESCRIPTION
We were formatting the timestamp in the build binaries of pixi-build-backends as `"%d%m%Y"` instead of `"%Y%m%d"`. The former is not monotonicity which can cause issues!