### PR TITLE
fix: add variants and sysroot 2.17

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -63,7 +63,7 @@ ruff = ">=0.12.9,<0.13"
 rattler-build = ">=0.30.0,<1"
 
 [feature.build.tasks.build-recipe-ci]
-cmd = "rattler-build build --test native --channel https://prefix.dev/pixi-build-backends --channel https://prefix.dev/conda-forge --output-dir={{ output_dir }} --recipe {{ recipe }} --target-platform {{ target_platform }}"
+cmd = "rattler-build build --test native --channel https://prefix.dev/pixi-build-backends --channel https://prefix.dev/conda-forge --output-dir={{ output_dir }} --recipe {{ recipe }} --target-platform {{ target_platform }} --variant-config recipe/variants.yaml"
 args = ["output_dir", "recipe", "target_platform"]
 
 [feature.build.tasks.build-recipe]

--- a/recipe/pixi-build-cmake/recipe.yaml
+++ b/recipe/pixi-build-cmake/recipe.yaml
@@ -34,6 +34,7 @@ build:
 requirements:
   build:
     - ${{ compiler("rust") }}
+    - ${{ stdlib("c") }}
     - cargo-bundle-licenses
     - cargo-auditable
   host:

--- a/recipe/pixi-build-mojo/recipe.yaml
+++ b/recipe/pixi-build-mojo/recipe.yaml
@@ -34,6 +34,7 @@ build:
 requirements:
   build:
     - ${{ compiler("rust") }}
+    - ${{ stdlib("c") }}
     - cargo-bundle-licenses
     - cargo-auditable
   host:

--- a/recipe/pixi-build-python/recipe.yaml
+++ b/recipe/pixi-build-python/recipe.yaml
@@ -34,6 +34,7 @@ build:
 requirements:
   build:
     - ${{ compiler("rust") }}
+    - ${{ stdlib("c") }}
     - cargo-bundle-licenses
     - cargo-auditable
   host:

--- a/recipe/pixi-build-rattler-build/recipe.yaml
+++ b/recipe/pixi-build-rattler-build/recipe.yaml
@@ -34,6 +34,7 @@ build:
 requirements:
   build:
     - ${{ compiler("rust") }}
+    - ${{ stdlib("c") }}
     - cargo-bundle-licenses
     - cargo-auditable
   host:

--- a/recipe/pixi-build-rust/recipe.yaml
+++ b/recipe/pixi-build-rust/recipe.yaml
@@ -34,6 +34,7 @@ build:
 requirements:
   build:
     - ${{ compiler("rust") }}
+    - ${{ stdlib("c") }}
     - cargo-bundle-licenses
     - cargo-auditable
   host:

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -1,0 +1,43 @@
+# This is a semi distilled variant config from conda-forge.
+#
+# It adds sysroot (2.17) for linux, macosx_deployment_target for osx
+# and uses vs2022 for windows.
+#
+c_stdlib:
+  - if: linux
+    then: sysroot
+  - if: osx
+    then: macosx_deployment_target
+  - if: win
+    then: vs
+c_stdlib_version:
+  - if: linux
+    then: 2.17
+  - if: osx and x86_64
+    then: 10.13
+  - if: osx and arm64
+    then: 11.0
+c_compiler:
+  - if: linux
+    then: gcc
+  - if: osx
+    then: clang
+  - if: win
+    then: vs2022
+c_compiler_version:
+  - if: linux
+    then: 14
+  - if: osx
+    then: 19
+cxx_compiler:
+  - if: linux
+    then: gxx
+  - if: osx
+    then: clangxx
+  - if: win
+    then: vs2022
+cxx_compiler_version:
+  - if: linux
+    then: 14
+  - if: osx
+    then: 19


### PR DESCRIPTION
Fixes https://github.com/prefix-dev/pixi-build-backends/issues/327

This PR adds a distilled version of the conda-forge pinnings, which includes a sysroot for glibc 2.17.