### PR TITLE
feat: implement default_variants for python implementation

### DIFF
--- a/backends/pixi-build-ros/src/pixi_build_ros/ros_generator.py
+++ b/backends/pixi-build-ros/src/pixi_build_ros/ros_generator.py
@@ -144,7 +144,12 @@ class ROSGenerator(GenerateRecipeProtocol):
         """Extract input globs for the build."""
         return get_build_input_globs(config, editable)
 
-
+    def default_variants(self, host_platform: Platform ) -> Dict[str, Any]:
+        """Get the default variants for the generator."""
+        variants = {}
+        if host_platform.is_windows:
+            variants["cxx_compiler"] = ["vs2019"]
+        return variants
 
 def merge_requirements(model_requirements: ConditionalRequirements, package_requirements: ConditionalRequirements) -> ConditionalRequirements:
     """Merge two sets of requirements."""

--- a/crates/pixi-build-backend/src/generated_recipe.rs
+++ b/crates/pixi-build-backend/src/generated_recipe.rs
@@ -80,8 +80,11 @@ pub trait GenerateRecipe {
     /// This can be useful to change the default behavior of rattler-build with
     /// regard to compilers. But it also allows setting up default build
     /// matrices.
-    fn default_variants(&self, _host_platform: Platform) -> BTreeMap<NormalizedKey, Vec<Variable>> {
-        BTreeMap::new()
+    fn default_variants(
+        &self,
+        _host_platform: Platform,
+    ) -> miette::Result<BTreeMap<NormalizedKey, Vec<Variable>>> {
+        Ok(BTreeMap::new())
     }
 }
 

--- a/crates/pixi-build-backend/src/intermediate_backend.rs
+++ b/crates/pixi-build-backend/src/intermediate_backend.rs
@@ -271,7 +271,7 @@ where
         // Determine the variant configuration to use. This is a combination of defaults
         // from the generator and the user supplied parameters. The parameters
         // from the user take precedence over the default variants.
-        let recipe_variants = self.generate_recipe.default_variants(host_platform);
+        let recipe_variants = self.generate_recipe.default_variants(host_platform)?;
         let mut param_variant_configuration = params
             .variant_configuration
             .unwrap_or_default()
@@ -581,7 +581,7 @@ where
         // Determine the variant configuration to use. This is a combination of defaults
         // from the generator and the user supplied parameters. The parameters
         // from the user take precedence over the default variants.
-        let recipe_variants = self.generate_recipe.default_variants(host_platform);
+        let recipe_variants = self.generate_recipe.default_variants(host_platform)?;
         let param_variants =
             convert_input_variant_configuration(params.variant_configuration).unwrap_or_default();
         let variants = BTreeMap::from_iter(itertools::chain!(recipe_variants, param_variants));
@@ -841,7 +841,9 @@ where
         // Determine the variant configuration to use. This is a combination of defaults
         // from the generator and the user supplied parameters. The parameters
         // from the user take precedence over the default variants.
-        let recipe_variants = self.generate_recipe.default_variants(params.host_platform);
+        let recipe_variants = self
+            .generate_recipe
+            .default_variants(params.host_platform)?;
         let param_variants =
             convert_input_variant_configuration(params.variant_configuration).unwrap_or_default();
         let variants = BTreeMap::from_iter(itertools::chain!(recipe_variants, param_variants));

--- a/crates/pixi-build-cmake/src/main.rs
+++ b/crates/pixi-build-cmake/src/main.rs
@@ -118,7 +118,10 @@ impl GenerateRecipe for CMakeGenerator {
         .collect())
     }
 
-    fn default_variants(&self, host_platform: Platform) -> BTreeMap<NormalizedKey, Vec<Variable>> {
+    fn default_variants(
+        &self,
+        host_platform: Platform,
+    ) -> miette::Result<BTreeMap<NormalizedKey, Vec<Variable>>> {
         let mut variants = BTreeMap::new();
 
         if host_platform.is_windows() {
@@ -129,7 +132,7 @@ impl GenerateRecipe for CMakeGenerator {
             variants.insert(NormalizedKey::from("cxx_compiler"), vec!["vs2019".into()]);
         }
 
-        variants
+        Ok(variants)
     }
 }
 

--- a/crates/pixi-build-mojo/src/main.rs
+++ b/crates/pixi-build-mojo/src/main.rs
@@ -11,7 +11,7 @@ use pixi_build_backend::{
     intermediate_backend::IntermediateBackendInstantiator,
 };
 use rattler_build::NormalizedKey;
-use rattler_conda_types::PackageName;
+use rattler_conda_types::{PackageName, Platform};
 use recipe_stage0::recipe::{ConditionalRequirements, Script};
 use std::collections::HashSet;
 use std::{collections::BTreeSet, path::Path, sync::Arc};
@@ -27,7 +27,7 @@ impl GenerateRecipe for MojoGenerator {
         model: &pixi_build_types::ProjectModelV1,
         config: &Self::Config,
         manifest_root: std::path::PathBuf,
-        host_platform: rattler_conda_types::Platform,
+        host_platform: Platform,
         _python_params: Option<PythonParams>,
         variants: &HashSet<NormalizedKey>,
     ) -> miette::Result<GeneratedRecipe> {

--- a/crates/pixi-build-mojo/src/main.rs
+++ b/crates/pixi-build-mojo/src/main.rs
@@ -126,10 +126,6 @@ impl GenerateRecipe for MojoGenerator {
             .chain(config.extra_input_globs.clone())
             .collect())
     }
-
-    fn default_variants(&self, _host_platform: Platform) -> BTreeMap<NormalizedKey, Vec<Variable>> {
-        BTreeMap::new()
-    }
 }
 
 impl MojoGenerator {

--- a/crates/pixi-build-mojo/src/main.rs
+++ b/crates/pixi-build-mojo/src/main.rs
@@ -10,15 +10,11 @@ use pixi_build_backend::{
     generated_recipe::{GenerateRecipe, GeneratedRecipe, PythonParams},
     intermediate_backend::IntermediateBackendInstantiator,
 };
-use rattler_build::{NormalizedKey, recipe::variable::Variable};
-use rattler_conda_types::{PackageName, Platform};
+use rattler_build::NormalizedKey;
+use rattler_conda_types::PackageName;
 use recipe_stage0::recipe::{ConditionalRequirements, Script};
 use std::collections::HashSet;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    path::Path,
-    sync::Arc,
-};
+use std::{collections::BTreeSet, path::Path, sync::Arc};
 
 #[derive(Default, Clone)]
 pub struct MojoGenerator {}

--- a/py-pixi-build-backend/Cargo.lock
+++ b/py-pixi-build-backend/Cargo.lock
@@ -4747,6 +4747,7 @@ dependencies = [
  "pyo3-async-runtimes",
  "pyo3-build-config 0.25.1",
  "pythonize",
+ "rattler-build",
  "rattler_conda_types 0.39.0",
  "rattler_package_streaming 0.23.1",
  "rattler_virtual_packages 2.1.3",

--- a/py-pixi-build-backend/Cargo.toml
+++ b/py-pixi-build-backend/Cargo.toml
@@ -43,6 +43,7 @@ rattler_conda_types = { version = "0.39.0", default-features = false }
 rattler_package_streaming = { version = "0.23.1", default-features = false }
 rattler_virtual_packages = { version = "2.0.9", default-features = false }
 
+rattler-build = "*"
 
 # Error handling
 miette = "7.5.0"

--- a/py-pixi-build-backend/pixi_build_backend/types/generated_recipe.py
+++ b/py-pixi-build-backend/pixi_build_backend/types/generated_recipe.py
@@ -76,7 +76,10 @@ class GenerateRecipeProtocol(Protocol):
     def extract_input_globs_from_build(self, config: dict[str, Any], workdir: Path, editable: bool) -> List[str]:
         """Extract input globs for the build."""
         ...
-
+    
+    def default_variants(self, host_platform: Platform ) -> Dict[str, Any]:
+        """Get the default variants for the generator."""
+        ...
 
 class GenerateRecipe:
     """Protocol for generating recipes."""

--- a/py-pixi-build-backend/src/types/generated_recipe.rs
+++ b/py-pixi-build-backend/src/types/generated_recipe.rs
@@ -1,18 +1,5 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::Path;
-
-use miette::IntoDiagnostic;
-use pixi_build_backend::generated_recipe::{
-    DefaultMetadataProvider, GenerateRecipe, GeneratedRecipe,
-};
-use pixi_build_backend::variants::NormalizedKey;
-use pyo3::{
-    Py, PyErr, PyObject, PyResult, Python,
-    exceptions::PyValueError,
-    pyclass, pymethods,
-    types::{PyAnyMethods, PyString},
-};
-use recipe_stage0::recipe::IntermediateRecipe;
 
 use crate::{
     create_py_wrap,
@@ -20,6 +7,20 @@ use crate::{
     types::metadata_provider::get_input_globs_from_provider,
     types::{PyBackendConfig, PyMetadataProvider, PyPlatform, PyProjectModelV1, PyPythonParams},
 };
+use miette::IntoDiagnostic;
+use pixi_build_backend::generated_recipe::{
+    DefaultMetadataProvider, GenerateRecipe, GeneratedRecipe,
+};
+use pyo3::{
+    Py, PyErr, PyObject, PyResult, Python,
+    exceptions::PyValueError,
+    pyclass, pymethods,
+    types::{PyAnyMethods, PyString},
+};
+use rattler_build::render::resolved_dependencies::DependencyInfo::Variant;
+use rattler_build::{NormalizedKey, recipe::variable::Variable};
+use rattler_conda_types::Platform;
+use recipe_stage0::recipe::IntermediateRecipe;
 
 create_py_wrap!(PyVecString, Vec<String>, |v: &Vec<String>,
                                            f: &mut std::fmt::Formatter<
@@ -273,6 +274,30 @@ impl GenerateRecipe for PyGenerateRecipe {
                 .into_iter()
                 .collect::<BTreeSet<String>>();
             Ok::<_, miette::Report>(input_globs)
+        })
+    }
+
+    fn default_variants(
+        &self,
+        host_platform: Platform,
+    ) -> miette::Result<BTreeMap<NormalizedKey, Vec<Variable>>> {
+        Python::with_gil(|py| {
+            let variants_dict = self
+                .model
+                .bind(py)
+                .call_method("default_variants", (PyPlatform::from(host_platform),), None)
+                .into_diagnostic()?
+                .extract::<BTreeMap<String, Vec<String>>>()
+                .into_diagnostic()?;
+
+            let mut variants = BTreeMap::new();
+            for (key, values) in variants_dict {
+                variants.insert(
+                    NormalizedKey::from(key),
+                    values.into_iter().map(Variable::from).collect(),
+                );
+            }
+            Ok::<_, miette::Report>(variants)
         })
     }
 }


### PR DESCRIPTION
Implementing `default_variants` function in the GenerateRecipe trait for the Python bindings.

This is important for the Windows builds of the ROS packages as it otherwise defaults to `vs2015` which is too old. 