### PR TITLE
fix(rattler-build): add recipe.yaml to input globs

### DIFF
--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -450,9 +450,15 @@ impl Protocol for RattlerBuildBackend {
             });
         }
 
+        let mut input_globs = variant_config.input_globs;
+        input_globs.extend(get_metadata_input_globs(
+            &self.manifest_root,
+            &self.recipe_source.path,
+        )?);
+
         Ok(CondaOutputsResult {
             outputs,
-            input_globs: variant_config.input_globs,
+            input_globs,
         })
     }
 

--- a/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@boltons__recipe.yaml.snap
+++ b/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@boltons__recipe.yaml.snap
@@ -41,6 +41,7 @@ input_file: tests/recipe/boltons/recipe.yaml
     }
   ],
   "inputGlobs": [
+    "recipe.yaml",
     "variants.yaml"
   ]
 }

--- a/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@pin-subpackage-variants__recipe.yaml.snap
+++ b/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@pin-subpackage-variants__recipe.yaml.snap
@@ -157,6 +157,7 @@ input_file: tests/recipe/pin-subpackage-variants/recipe.yaml
     }
   ],
   "inputGlobs": [
+    "recipe.yaml",
     "variants.yaml"
   ]
 }

--- a/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@pin-subpackage__recipe.yaml.snap
+++ b/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@pin-subpackage__recipe.yaml.snap
@@ -46,6 +46,7 @@ input_file: tests/recipe/pin-subpackage/recipe.yaml
     }
   ],
   "inputGlobs": [
+    "recipe.yaml",
     "variants.yaml"
   ]
 }

--- a/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@variants__recipe.yaml.snap
+++ b/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@variants__recipe.yaml.snap
@@ -100,6 +100,7 @@ input_file: tests/recipe/variants/recipe.yaml
     }
   ],
   "inputGlobs": [
+    "recipe.yaml",
     "variants.yaml"
   ]
 }


### PR DESCRIPTION
Should fix prefix-dev/pixi#4500.