### PR TITLE
fix: add force option for symbolic linking

### DIFF
--- a/backends/pixi-build-ros/templates/build_ament_cmake.sh
+++ b/backends/pixi-build-ros/templates/build_ament_cmake.sh
@@ -51,12 +51,6 @@ if [[ $target_platform =~ linux.* ]]; then
 fi;
 
 
-# TODO: test the ln on macos
-touch jorik.txt
-ln -sf jorik.txt ${BUILD_PREFIX}/jorik_link.txt
-
-
-
 # PYTHON_INSTALL_DIR should be a relative path, see
 # https://github.com/ament/ament_cmake/blob/2.3.2/ament_cmake_python/README.md
 # So we compute the relative path of $SP_DIR w.r.t. to $PREFIX,

--- a/backends/pixi-build-ros/templates/build_ament_cmake.sh
+++ b/backends/pixi-build-ros/templates/build_ament_cmake.sh
@@ -46,9 +46,16 @@ fi;
 
 # Needed for qt-gui-cpp ..
 if [[ $target_platform =~ linux.* ]]; then
-  ln -s $GCC ${BUILD_PREFIX}/bin/gcc
-  ln -s $GXX ${BUILD_PREFIX}/bin/g++
+  ln --symbolic --force $GCC ${BUILD_PREFIX}/bin/gcc
+  ln --symbolic --force $GXX ${BUILD_PREFIX}/bin/g++
 fi;
+
+
+# TODO: test the ln on macos
+touch jorik.txt
+ln -sf jorik.txt ${BUILD_PREFIX}/jorik_link.txt
+
+
 
 # PYTHON_INSTALL_DIR should be a relative path, see
 # https://github.com/ament/ament_cmake/blob/2.3.2/ament_cmake_python/README.md


### PR DESCRIPTION
## Overview

This fix is mostly focused for linux platform, as it can only happen under this condition in the build script.
```
f [[ $target_platform =~ linux.* ]]
```

Tested on Mac by adding this in the build script
```
touch jorik.txt
ln -sf jorik.txt ${BUILD_PREFIX}/jorik_link.txt
```
