### PR TITLE
fix: add entry points to pixi-build-ros

### DIFF
--- a/recipe/pixi-build-ros/recipe.yaml
+++ b/recipe/pixi-build-ros/recipe.yaml
@@ -25,6 +25,7 @@ requirements:
     - pixi-build-api-version >=2,<3
 
 build:
+  number: 1
   script:
     - pip install . -vv --no-build-isolation
   noarch: python


### PR DESCRIPTION
Bug: Missing Windows Executable for pixi-build-ros
Fixes #364