### PR TITLE
fix(ros): add ci for pixi-build-ros

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -1,0 +1,42 @@
+name: ROS Build backend
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      # When we change code that bindings depend on, we want to ensure that the maturin builds still work
+      - crates/pixi-build-backend/**
+      - Cargo.*
+      - py-pixi-build-backend/**
+
+      # When something in the ros-build package themselves changes
+      - backends/pixi-build-ros/**
+
+      # Or when this workflow changes
+      - .github/workflows/ros-build.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test the pixi-build-ros package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: recursive
+      - uses: prefix-dev/setup-pixi@194d461b21b6c5717c722ffc597fa91ed2ff29fa # v0.9.1
+        with:
+          manifest-path: backends/pixi-build-ros/pixi.toml
+          environments: test
+      - name: Run tests
+        run: |
+          cd backends/pixi-build-ros
+          pixi run -e test test --color=yes


### PR DESCRIPTION
Added a ci workflow for the `pixi-build-ros` package. 