### PR TITLE
fix: extra-input-globs

### DIFF
--- a/backends/pixi-build-ros/src/pixi_build_ros/metadata_provider.py
+++ b/backends/pixi-build-ros/src/pixi_build_ros/metadata_provider.py
@@ -44,7 +44,13 @@ class PackageXmlMetadataProvider(MetadataProvider):  # type: ignore[misc]  # Met
     like name, version, description, maintainers, etc.
     """
 
-    def __init__(self, package_xml_path: str, *args, **kwargs):  # type: ignore[no-untyped-def]  # no typing for args and kwargs
+    def __init__(  # type: ignore[no-untyped-def]  # no typing for args and kwargs
+        self,
+        package_xml_path: str,
+        *args,
+        extra_input_globs: list[str] | None = None,
+        **kwargs,
+    ):
         """
         Initialize the metadata provider with a package.xml file path.
 
@@ -54,6 +60,7 @@ class PackageXmlMetadataProvider(MetadataProvider):  # type: ignore[misc]  # Met
         super().__init__(*args, **kwargs)
         self.package_xml_path = package_xml_path
         self._package_data: PackageData | None = None
+        self._extra_input_globs = list(extra_input_globs or [])
         # Early load the package.xml data to ensure it's valid
         _ = self._package_xml_data
 
@@ -162,7 +169,8 @@ class PackageXmlMetadataProvider(MetadataProvider):  # type: ignore[misc]  # Met
 
     def input_globs(self) -> list[str]:
         """Return input globs that affect this metadata provider."""
-        return ["package.xml", "CMakeLists.txt", "setup.py", "setup.cfg"]
+        base_globs = ["package.xml", "CMakeLists.txt", "setup.py", "setup.cfg"]
+        return list(set(base_globs + self._extra_input_globs))
 
 
 class ROSPackageXmlMetadataProvider(PackageXmlMetadataProvider):
@@ -173,7 +181,13 @@ class ROSPackageXmlMetadataProvider(PackageXmlMetadataProvider):
     as 'ros-<distro>-<package_name>' according to ROS conda packaging conventions.
     """
 
-    def __init__(self, package_xml_path: str, distro_name: str | None = None):
+    def __init__(
+        self,
+        package_xml_path: str,
+        distro_name: str | None = None,
+        *,
+        extra_input_globs: list[str] | None = None,
+    ):
         """
         Initialize the ROS metadata provider.
 
@@ -181,7 +195,7 @@ class ROSPackageXmlMetadataProvider(PackageXmlMetadataProvider):
             package_xml_path: Path to the package.xml file
             distro: ROS distro. If None, will use the base package name without distro prefix.
         """
-        super().__init__(package_xml_path)
+        super().__init__(package_xml_path, extra_input_globs=extra_input_globs)
         self._distro_name: str | None = distro_name
 
     def name(self) -> str | None:

--- a/backends/pixi-build-ros/src/pixi_build_ros/ros_generator.py
+++ b/backends/pixi-build-ros/src/pixi_build_ros/ros_generator.py
@@ -47,7 +47,11 @@ class ROSGenerator(GenerateRecipeProtocol):  # type: ignore[misc]  # MetadatProv
         )
         # Create metadata provider for package.xml
         package_xml_path = manifest_root / "package.xml"
-        metadata_provider = ROSPackageXmlMetadataProvider(str(package_xml_path), backend_config.distro.name)
+        metadata_provider = ROSPackageXmlMetadataProvider(
+            str(package_xml_path),
+            backend_config.distro.name,
+            extra_input_globs=list(backend_config.extra_input_globs or []),
+        )
 
         # Create base recipe from model with metadata provider
         generated_recipe = GeneratedRecipe.from_model(model, metadata_provider)

--- a/backends/pixi-build-ros/src/pixi_build_ros/utils.py
+++ b/backends/pixi-build-ros/src/pixi_build_ros/utils.py
@@ -50,8 +50,8 @@ def get_build_input_globs(config: dict[str, Any], editable: bool) -> list[str]:
     python_globs = [] if editable else ["**/*.py", "**/*.pyx"]
 
     all_globs = base_globs + python_globs
-    if config.get("extra_input_globs"):
-        all_globs.extend(config["extra_input_globs"])
+    if config.get("extra-input-globs"):
+        all_globs.extend(config["extra-input-globs"])
     return all_globs
 
 


### PR DESCRIPTION
#392 introduced regression and `extra-input-globs` stopped working, this PR fixes this and also fixes metadata provider to output extra-input-globs so they are stored in the `metadata.json`.