### PR TITLE
add python variant to variants.yaml

### DIFF
--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -41,6 +41,8 @@ cxx_compiler_version:
     then: 14
   - if: osx
     then: 19
+python:
+  - 3.13
 
 # Pin the compiler used
 rust_compiler_version:


### PR DESCRIPTION
Looking at this failing CI: https://github.com/prefix-dev/pixi-build-backends/actions/runs/18490610838/job/52683126933

It seems like it picked up the latest version of python which doesn't work. 

This should limit the version for now.