### PR TITLE
fix: fix target-specific documentation

### DIFF
--- a/docs/backends/pixi-build-cmake.md
+++ b/docs/backends/pixi-build-cmake.md
@@ -78,7 +78,7 @@ For target-specific configuration, platform arguments completely replace the bas
 [package.build.config]
 extra-args = ["-DCMAKE_BUILD_TYPE=Release"]
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 extra-args = ["-DCMAKE_BUILD_TYPE=Debug", "-DLINUX_FLAG=ON"]
 # Result for linux-64: ["-DCMAKE_BUILD_TYPE=Debug", "-DLINUX_FLAG=ON"]
 ```
@@ -102,7 +102,7 @@ For target-specific configuration, platform environment variables are merged wit
 [package.build.config]
 env = { CMAKE_VERBOSE_MAKEFILE = "OFF", COMMON_VAR = "base" }
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 env = { COMMON_VAR = "linux", LINUX_VAR = "value" }
 # Result for linux-64: { CMAKE_VERBOSE_MAKEFILE = "OFF", COMMON_VAR = "linux", LINUX_VAR = "value" }
 ```
@@ -134,7 +134,7 @@ For target-specific configuration, platform-specific globs completely replace th
 [package.build.config]
 extra-input-globs = ["*.txt"]
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 extra-input-globs = ["*.txt", "*.linux", "linux-configs/**/*"]
 # Result for linux-64: ["*.txt", "*.linux", "linux-configs/**/*"]
 ```
@@ -158,7 +158,7 @@ For target-specific configuration, platform compilers completely replace the bas
 [package.build.config]
 compilers = ["cxx"]
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 compilers = ["c", "cxx", "cuda"]
 # Result for linux-64: ["c", "cxx", "cuda"]
 ```

--- a/docs/backends/pixi-build-mojo.md
+++ b/docs/backends/pixi-build-mojo.md
@@ -193,7 +193,7 @@ For target-specific configuration, platform compilers completely replace the bas
 [package.build.config]
 compilers = ["mojo"]
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 compilers = ["mojo", "c", "cuda"]
 # Result for linux-64: ["mojo", "c", "cuda"]
 ```

--- a/docs/backends/pixi-build-python.md
+++ b/docs/backends/pixi-build-python.md
@@ -83,7 +83,7 @@ For target-specific configuration, platform-specific noarch setting overrides th
 [package.build.config]
 noarch = true
 
-[package.build.config.targets.win-64]
+[package.build.target.win-64.config]
 noarch = false  # Windows needs platform build
 # Result for win-64: false
 ```
@@ -107,7 +107,7 @@ For target-specific configuration, platform environment variables are merged wit
 [package.build.config]
 env = { PYTHONPATH = "/base/path", COMMON_VAR = "base" }
 
-[package.build.config.targets.win-64]
+[package.build.target.win-64.config]
 env = { COMMON_VAR = "windows", WIN_SPECIFIC = "value" }
 # Result for win-64: { PYTHONPATH = "/base/path", COMMON_VAR = "windows", WIN_SPECIFIC = "value" }
 ```
@@ -138,7 +138,7 @@ For target-specific configuration, platform-specific globs completely replace th
 [package.build.config]
 extra-input-globs = ["*.py"]
 
-[package.build.config.targets.win-64]
+[package.build.target.win-64.config]
 extra-input-globs = ["*.py", "*.dll", "*.pyd", "windows-resources/**/*"]
 # Result for win-64: ["*.py", "*.dll", "*.pyd", "windows-resources/**/*"]
 ```
@@ -162,7 +162,7 @@ For target-specific configuration, platform compilers completely replace the bas
 [package.build.config]
 compilers = []
 
-[package.build.config.targets.win-64]
+[package.build.target.win-64.config]
 compilers = ["c", "cxx"]
 # Result for win-64: ["c", "cxx"] (only on Windows)
 ```
@@ -203,7 +203,7 @@ For target-specific configuration, platform-specific globs completely replace th
 [package.build.config]
 extra-args = ["-Cbuilddir=mybuilddir"]
 
-[package.build.config.targets.win-64]
+[package.build.target.win-64.config]
 extra-args = ["-Cbuilddir=foo"]
 # Result for win-64: ["-Cbuilddir=foo"]
 ```
@@ -229,7 +229,7 @@ For target-specific configuration, platform-specific setting overrides the base:
 [package.build.config]
 ignore-pyproject-manifest = false
 
-[package.build.config.targets.win-64]
+[package.build.target.win-64.config]
 ignore-pyproject-manifest = true  # Ignore pyproject.toml on Windows only
 # Result for win-64: true
 ```

--- a/docs/backends/pixi-build-rattler-build.md
+++ b/docs/backends/pixi-build-rattler-build.md
@@ -113,7 +113,7 @@ For target-specific configuration, platform-specific globs completely replace th
 [package.build.config]
 extra-input-globs = ["*.yaml", "*.md"]
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 extra-input-globs = ["*.yaml", "*.md", "*.sh", "patches-linux/**/*"]
 # Result for linux-64: ["*.yaml", "*.md", "*.sh", "patches-linux/**/*"]
 ```

--- a/docs/backends/pixi-build-rust.md
+++ b/docs/backends/pixi-build-rust.md
@@ -116,7 +116,7 @@ For target-specific configuration, platform arguments completely replace the bas
 [package.build.config]
 extra-args = ["--release"]
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 extra-args = ["--features", "linux-specific", "--target", "x86_64-unknown-linux-gnu"]
 # Result for linux-64: ["--features", "linux-specific", "--target", "x86_64-unknown-linux-gnu"]
 ```
@@ -140,7 +140,7 @@ For target-specific configuration, platform environment variables are merged wit
 [package.build.config]
 env = { RUST_LOG = "info", COMMON_VAR = "base" }
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 env = { COMMON_VAR = "linux", CARGO_PROFILE_RELEASE_LTO = "true" }
 # Result for linux-64: { RUST_LOG = "info", COMMON_VAR = "linux", CARGO_PROFILE_RELEASE_LTO = "true" }
 ```
@@ -172,7 +172,7 @@ For target-specific configuration, platform-specific globs completely replace th
 [package.build.config]
 extra-input-globs = ["*.txt"]
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 extra-input-globs = ["*.txt", "*.so", "linux-configs/**/*"]
 # Result for linux-64: ["*.txt", "*.so", "linux-configs/**/*"]
 ```
@@ -203,7 +203,7 @@ For target-specific configuration:
 [package.build.config]
 ignore-cargo-manifest = false
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 ignore-cargo-manifest = true
 # Result for linux-64: Cargo.toml metadata will be ignored
 ```
@@ -227,7 +227,7 @@ For target-specific configuration, platform compilers completely replace the bas
 [package.build.config]
 compilers = ["rust"]
 
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 compilers = ["rust", "c", "cxx"]
 # Result for linux-64: ["rust", "c", "cxx"]
 ```

--- a/docs/key_concepts/compilers.md
+++ b/docs/key_concepts/compilers.md
@@ -181,10 +181,10 @@ compilers = ["c", "cxx", "fortran"]
 compilers = ["cxx"]
 
 # Linux needs additional CUDA support
-[package.build.config.targets.linux-64]
+[package.build.target.linux-64.config]
 compilers = ["cxx", "cuda"]
 
 # Windows needs additional C compiler for some dependencies
-[package.build.config.targets.win-64]
+[package.build.target.win-64.config]
 compilers = ["c", "cxx"]
 ```


### PR DESCRIPTION
# Overview

Fix target-specific documentation as done in https://github.com/prefix-dev/pixi/pull/4882
Documented syntax is wrong: `[package.build.config.targets.linux-64]` -> `[package.build.target.linux-64.config]`

Close #448 