### PR TITLE
fix: do not verify what is the filename

### DIFF
--- a/backends/pixi-build-ros/src/pixi_build_ros/ros_generator.py
+++ b/backends/pixi-build-ros/src/pixi_build_ros/ros_generator.py
@@ -50,8 +50,6 @@ class ROSGenerator(GenerateRecipeProtocol):  # type: ignore[misc]  # MetadatProv
         # an absolute path to package.xml or a directory containing it
         # so I'm handling both cases
         if manifest_path_obj.is_file():
-            if manifest_path_obj.name != "package.xml":
-                raise ValueError("Manifest filename must be package.xml for ROS packages.")
             manifest_root = manifest_path_obj.parent
         else:
             manifest_root = manifest_path_obj


### PR DESCRIPTION
## Overview

We have an usecase in pixi-build-testsuite where I can point to a pixi.toml with some package configuration:
https://github.com/prefix-dev/pixi-build-testsuite/blob/main/tests/data/pixi_build/ros-workspace/src/navigator/pixi.toml

but still want that the backend should detect the package.xml.

In our case, we always verify what is the filename which is wrong.