### PR TITLE
feat: add extra-args config option to rattler-build backend

### DIFF
--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -69,7 +69,7 @@ impl Protocol for RattlerBuildBackend {
             build_platform,
             hash: None,
             variant: Default::default(),
-            experimental: false,
+            experimental: self.config.experimental(),
             allow_undefined: false,
             recipe_path: Some(self.recipe_source.path.clone()),
         };
@@ -299,7 +299,7 @@ impl Protocol for RattlerBuildBackend {
             build_platform,
             hash: None,
             variant: Default::default(),
-            experimental: false,
+            experimental: self.config.experimental(),
             allow_undefined: false,
             recipe_path: Some(self.recipe_source.path.clone()),
         };

--- a/docs/backends/pixi-build-rattler-build.md
+++ b/docs/backends/pixi-build-rattler-build.md
@@ -118,6 +118,33 @@ extra-input-globs = ["*.yaml", "*.md", "*.sh", "patches-linux/**/*"]
 # Result for linux-64: ["*.yaml", "*.md", "*.sh", "patches-linux/**/*"]
 ```
 
+### `extra-args`
+
+- **Type**: `Array<String>`
+- **Default**: `[]`
+- **Target Merge Behavior**: `Overwrite` - Platform-specific args completely replace base args
+
+Extra arguments to pass to rattler-build. This allows you to enable experimental features or pass other CLI flags without needing backend updates.
+
+Currently supported arguments:
+
+- `--experimental`: Enable experimental features (e.g., `cache:` support for multi-output recipes)
+
+```toml
+[package.build.config]
+extra-args = ["--experimental"]
+```
+
+For target-specific configuration, platform-specific args completely replace the base:
+
+```toml
+[package.build.config]
+extra-args = ["--experimental"]
+
+[package.build.target.linux-64.config]
+extra-args = []  # Disable experimental for linux-64
+```
+
 ## Build Process
 
 The rattler-build backend follows this build process:


### PR DESCRIPTION
Add support for passing arbitrary arguments to rattler-build through
the `extra-args` configuration option. This enables users to enable
experimental features (like `cache:` support) without requiring
backend updates.

The `--experimental` flag is parsed from extra-args and enables
experimental mode in the SelectorConfig, which is needed for
multi-output recipes using the cache feature.

Closes #468