### PR TITLE
fix: use 2.17 sysroot

### DIFF
--- a/recipe/testsuite-backends/recipe.yaml
+++ b/recipe/testsuite-backends/recipe.yaml
@@ -14,7 +14,7 @@ cache:
     build:
       - ${{ compiler("rust") }}
       - ${{ stdlib("c") }}
-      - python 3.13.*
+      - python
     host:
       - liblzma
 
@@ -121,11 +121,11 @@ outputs:
 
     requirements:
       host:
-        - python 3.13.*
+        - python
         - hatchling
         - pip
       run:
-        - python 3.13.*
+        - python
         - rosdistro
         - catkin_pkg
         - pydantic

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -1,6 +1,6 @@
 # This is a semi distilled variant config from conda-forge.
 #
-# It adds sysroot (2.34) for linux, macosx_deployment_target for osx
+# It adds sysroot (2.17) for linux, macosx_deployment_target for osx
 # and uses vs2022 for windows.
 #
 c_stdlib:
@@ -12,7 +12,7 @@ c_stdlib:
     then: vs
 c_stdlib_version:
   - if: linux
-    then: 2.34
+    then: 2.17
   - if: osx and x86_64
     then: 10.13
   - if: osx and arm64


### PR DESCRIPTION
https://github.com/prefix-dev/pixi-build-backends/pull/395 changed the sysroot to 2.34 which is too new for certain HPC systems. This PR essentially reverts that. 