### PR TITLE
chore: bump pixi-build-api-version and fix variant conversion

### DIFF
--- a/crates/pixi-build-backend/src/dependencies.rs
+++ b/crates/pixi-build-backend/src/dependencies.rs
@@ -24,7 +24,10 @@ use rattler_conda_types::{
 };
 use thiserror::Error;
 
-use crate::{specs_conversion::from_source_url_to_source_package, traits::PackageSpec};
+use crate::{
+    specs_conversion::{convert_variant_from_pixi_build_types, from_source_url_to_source_package},
+    traits::PackageSpec,
+};
 
 /// A helper struct to extract match specs from a manifest.
 #[derive(Default)]
@@ -138,7 +141,7 @@ pub fn convert_input_variant_configuration(
                 (
                     k.into(),
                     v.into_iter()
-                        .map(|v| Variable::from_string(&v.to_string()))
+                        .map(convert_variant_from_pixi_build_types)
                         .collect(),
                 )
             })

--- a/crates/pixi-build-backend/src/specs_conversion.rs
+++ b/crates/pixi-build-backend/src/specs_conversion.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use minijinja::Value;
 use ordermap::OrderMap;
 use pixi_build_types::{
     BinaryPackageSpecV1, PackageSpecV1, SourcePackageSpecV1, TargetSelectorV1, TargetV1, TargetsV1,
@@ -8,9 +9,12 @@ use pixi_build_types::{
         CondaBuildV1RunExports,
     },
 };
-use rattler_build::render::resolved_dependencies::{
-    DependencyInfo, FinalizedDependencies, FinalizedRunDependencies, ResolvedDependencies,
-    RunExportDependency, SourceDependency,
+use rattler_build::{
+    recipe::variable::Variable,
+    render::resolved_dependencies::{
+        DependencyInfo, FinalizedDependencies, FinalizedRunDependencies, ResolvedDependencies,
+        RunExportDependency, SourceDependency,
+    },
 };
 use rattler_conda_types::{
     Channel, MatchSpec, PackageName, PackageNameMatcher, package::RunExportsJson,
@@ -20,6 +24,7 @@ use recipe_stage0::{
     recipe::{Conditional, ConditionalList, ConditionalRequirements, Item, ListOrItem},
     requirements::PackageSpecDependencies,
 };
+use serde::Deserialize;
 use url::Url;
 
 use crate::encoded_source_spec_url::EncodedSourceSpecUrl;
@@ -53,6 +58,21 @@ impl std::fmt::Display for PlatformKind {
             PlatformKind::Target => write!(f, "target"),
         }
     }
+}
+
+pub fn convert_variant_from_pixi_build_types(variant: pixi_build_types::VariantValue) -> Variable {
+    match variant {
+        pixi_build_types::VariantValue::String(s) => Variable::from(s),
+        pixi_build_types::VariantValue::Int(i) => Variable::from(i),
+        pixi_build_types::VariantValue::Bool(b) => Variable::from(b),
+    }
+}
+
+pub fn convert_variant_to_pixi_build_types(
+    variant: Variable,
+) -> Result<pixi_build_types::VariantValue, minijinja::Error> {
+    let value = Value::from(variant);
+    pixi_build_types::VariantValue::deserialize(value)
 }
 
 pub fn to_rattler_build_selector(

--- a/crates/pixi-build-backend/src/tools.rs
+++ b/crates/pixi-build-backend/src/tools.rs
@@ -24,7 +24,7 @@ use rattler_conda_types::{GenericVirtualPackage, Platform, package::ArchiveType}
 use rattler_virtual_packages::VirtualPackageOverrides;
 use url::Url;
 
-use crate::source::Source;
+use crate::{source::Source, specs_conversion::convert_variant_from_pixi_build_types};
 
 /// A `recipe.yaml` file might be accompanied by a `variants.toml` file from
 /// which we can read variant configuration for that specific recipe..
@@ -98,16 +98,14 @@ impl LoadedVariantConfig {
 
     pub fn extend_with_input_variants(
         mut self,
-        input_variant_configuration: &BTreeMap<String, Vec<pixi_build_types::VariantValue>>,
+        input_variant_configuration: BTreeMap<String, Vec<pixi_build_types::VariantValue>>,
     ) -> Self {
         for (k, v) in input_variant_configuration {
             let variables = v
-                .iter()
-                .map(|v| rattler_build::recipe::variable::Variable::from_string(&v.to_string()))
+                .into_iter()
+                .map(convert_variant_from_pixi_build_types)
                 .collect();
-            self.variant_config
-                .variants
-                .insert(k.as_str().into(), variables);
+            self.variant_config.variants.insert(k.into(), variables);
         }
         self
     }

--- a/recipe/pixi-build-api-version/recipe.yaml
+++ b/recipe/pixi-build-api-version/recipe.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 context:
   name: pixi-build-api-version
-  version: "2"
+  version: "3"
 
 package:
   name: ${{ name }}

--- a/recipe/pixi-build-cmake/recipe.yaml
+++ b/recipe/pixi-build-cmake/recipe.yaml
@@ -44,7 +44,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=2,<3
+    - pixi-build-api-version >=2,<4
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-mojo/recipe.yaml
+++ b/recipe/pixi-build-mojo/recipe.yaml
@@ -44,7 +44,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=2,<3
+    - pixi-build-api-version >=2,<4
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-python/recipe.yaml
+++ b/recipe/pixi-build-python/recipe.yaml
@@ -44,7 +44,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=2,<3
+    - pixi-build-api-version >=2,<4
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-rattler-build/recipe.yaml
+++ b/recipe/pixi-build-rattler-build/recipe.yaml
@@ -44,7 +44,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=0,<3
+    - pixi-build-api-version >=2,<4
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/pixi-build-ros/recipe.yaml
+++ b/recipe/pixi-build-ros/recipe.yaml
@@ -24,7 +24,6 @@ requirements:
     - py-rattler
     - typing-extensions
     - py-pixi-build-backend
-    - pixi-build-api-version >=2,<3
 
 build:
   number: 0

--- a/recipe/pixi-build-rust/recipe.yaml
+++ b/recipe/pixi-build-rust/recipe.yaml
@@ -44,7 +44,7 @@ requirements:
     - if: unix
       then: openssl
   run:
-    - pixi-build-api-version >=2,<3
+    - pixi-build-api-version >=2,<4
 
 tests:
   - script: ${{ name }} --help

--- a/recipe/py-pixi-build-backend/recipe.yaml
+++ b/recipe/py-pixi-build-backend/recipe.yaml
@@ -26,7 +26,7 @@ requirements:
 
   run:
     - python >=3.8
-    - pixi-build-api-version >=2,<3
+    - pixi-build-api-version >=2,<4
   ignore_run_exports:
     from_package:
       - cross-python_${{ target_platform }}

--- a/recipe/testsuite-backends/recipe.yaml
+++ b/recipe/testsuite-backends/recipe.yaml
@@ -46,7 +46,7 @@ outputs:
 
     requirements:
       run:
-        - pixi-build-api-version >=2,<3
+        - pixi-build-api-version >=2,<4
 
     tests:
       - script:
@@ -62,7 +62,7 @@ outputs:
 
     requirements:
       run:
-        - pixi-build-api-version >=2,<3
+        - pixi-build-api-version >=2,<4
 
     tests:
       - script:
@@ -78,7 +78,7 @@ outputs:
 
     requirements:
       run:
-        - pixi-build-api-version >=2,<3
+        - pixi-build-api-version >=2,<4
 
     tests:
       - script:
@@ -94,7 +94,7 @@ outputs:
 
     requirements:
       run:
-        - pixi-build-api-version >=2,<3
+        - pixi-build-api-version >=2,<4
 
     tests:
       - script:
@@ -110,7 +110,7 @@ outputs:
 
     requirements:
       run:
-        - pixi-build-api-version >=2,<3
+        - pixi-build-api-version >=2,<4
 
     tests:
       - script:
@@ -133,7 +133,7 @@ outputs:
         - py-rattler
         - typing-extensions
         - py-pixi-build-backend
-        - pixi-build-api-version >=2,<3
+        - pixi-build-api-version >=2,<4
     build:
       script:
         - if: win


### PR DESCRIPTION
Two changes in one:

* Bumps the `pixi-build-api-version` to 3. Following https://github.com/prefix-dev/pixi/pull/4900
* Ensure variants are correctly converted and allow matching specifically on variants if available.