### PR TITLE
fix: correct build string in rattler-build-backend

### DIFF
--- a/crates/pixi-build-rattler-build/src/protocol.rs
+++ b/crates/pixi-build-rattler-build/src/protocol.rs
@@ -33,7 +33,7 @@ use rattler_build::{
     console_utils::LoggingOutputHandler,
     hash::HashInfo,
     metadata::{BuildConfiguration, Debug, Output, PlatformWithVirtualPackages},
-    recipe::{Jinja, ParsingError, Recipe, parser::find_outputs_from_src},
+    recipe::{ParsingError, Recipe, parser::find_outputs_from_src},
     selectors::SelectorConfig,
     tool_configuration::Configuration,
     types::{PackageIdentifier, PackagingSettings},
@@ -137,16 +137,12 @@ impl Protocol for RattlerBuildBackend {
                 continue;
             }
 
-            let jinja = Jinja::new(selector_config);
-            let build_number = recipe.build().number;
-            let build_string = recipe.build().string().resolve(&hash, build_number, &jinja);
-
             subpackages.insert(
                 recipe.package().name().clone(),
                 PackageIdentifier {
                     name: recipe.package().name().clone(),
                     version: recipe.package().version().version().clone().into(),
-                    build_string: build_string.to_string(),
+                    build_string: discovered_output.build_string.clone(),
                 },
             );
 
@@ -154,8 +150,8 @@ impl Protocol for RattlerBuildBackend {
                 metadata: CondaOutputMetadata {
                     name: recipe.package().name().clone(),
                     version: recipe.package.version().clone(),
-                    build: build_string.to_string(),
-                    build_number,
+                    build: discovered_output.build_string.clone(),
+                    build_number: recipe.build().number,
                     subdir: discovered_output.target_platform,
                     license: recipe.about.license.map(|l| l.to_string()),
                     license_family: recipe.about.license_family,

--- a/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@custom-build-string__recipe.yaml.snap
+++ b/crates/pixi-build-rattler-build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@custom-build-string__recipe.yaml.snap
@@ -1,0 +1,27 @@
+---
+source: crates/pixi-build-rattler-build/src/protocol.rs
+expression: conda_outputs_snapshot(result)
+input_file: tests/recipe/custom-build-string/recipe.yaml
+---
+{
+  "outputs": [
+    {
+      "metadata": {
+        "name": "python",
+        "version": "3.15",
+        "build": "0_cp315",
+        "buildNumber": 0,
+        "subdir": "linux-64",
+        "license": "Python-2.0",
+        "noarch": false,
+        "variant": {
+          "target_platform": "linux-64"
+        }
+      }
+    }
+  ],
+  "inputGlobs": [
+    "recipe.yaml",
+    "variants.yaml"
+  ]
+}

--- a/tests/recipe/custom-build-string/recipe.yaml
+++ b/tests/recipe/custom-build-string/recipe.yaml
@@ -1,0 +1,20 @@
+context:
+  # Keep up to date
+  version: "3.15"
+  variant: "default"
+  freethreading_tag: ${{ "t" if "free-threading" in variant else "" }}
+  abi_tag: cp${{ version | split(".") | join("") }}${{ freethreading_tag }}
+
+recipe:
+  name: python
+
+outputs:
+  - package:
+      name: python
+      version: ${{ version }}
+    build:
+      string: "0_${{ abi_tag }}"
+
+about:
+  homepage: https://www.python.org/
+  license: Python-2.0


### PR DESCRIPTION
The build string was not properly evaluated in the rattler-build outputs because we didnt take the context into account. This PR fixes that by simplifying the logic to use rattler-build internals. This hopefully provides more consistency.

Fixes https://github.com/prefix-dev/pixi/issues/5250