### PR TITLE
fix: add proper bounds to pixi-ros-backend

### DIFF
--- a/recipe/pixi-build-ros/recipe.yaml
+++ b/recipe/pixi-build-ros/recipe.yaml
@@ -23,7 +23,7 @@ requirements:
     - pyyaml
     - py-rattler
     - typing-extensions
-    - py-pixi-build-backend >=0.4.1
+    - py-pixi-build-backend >=0.4.1,<0.5
 
 build:
   number: 0


### PR DESCRIPTION
Set correct bounds on `py-pixi-build-backend` in `pixi-build-ros`.